### PR TITLE
Add support for non-function factories

### DIFF
--- a/__tests__/define.js
+++ b/__tests__/define.js
@@ -368,6 +368,11 @@ describe('Plugin for define blocks', () => {
     `).toBeTransformedTo(`
       module.exports = { thismodule: 'is an object' };
     `);
+    expect(`
+      define('auselessname', ['an', 'array', 'factory']);
+    `).toBeTransformedTo(`
+      module.exports = ['an', 'array', 'factory'];
+    `);
   });
 
   it('transforms named non-function modules with dependencies', () => {
@@ -376,6 +381,12 @@ describe('Plugin for define blocks', () => {
     `).toBeTransformedTo(`
       require('side-effect');
       module.exports = { thismodule: 'is an object' };
+    `);
+    expect(`
+      define('auselessname', ['side-effect'], ['an', 'array', 'factory']);
+    `).toBeTransformedTo(`
+      require('side-effect');
+      module.exports = ['an', 'array', 'factory'];
     `);
   });
 });

--- a/__tests__/define.js
+++ b/__tests__/define.js
@@ -280,4 +280,102 @@ describe('Plugin for define blocks', () => {
       }();
     `);
   });
+
+  it('transforms non-function modules exporting objects with no dependencies', () => {
+    expect(`
+      define({ thismodule: 'is an object' });
+    `).toBeTransformedTo(`
+      module.exports = { thismodule: 'is an object' };
+    `);
+  });
+
+  it('transforms non-function modules exporting objects with dependencies', () => {
+    expect(`
+      define(['side-effect'], { thismodule: 'is an object' });
+    `).toBeTransformedTo(`
+      require('side-effect');
+      module.exports = { thismodule: 'is an object' };
+    `);
+  });
+
+  it('transforms non-function modules exporting arrays with no dependencies', () => {
+    expect(`
+      define(['this', 'module', 'is', 'an', 'array']);
+    `).toBeTransformedTo(`
+      module.exports = ['this', 'module', 'is', 'an', 'array'];
+    `);
+  });
+
+  it('transforms non-function modules exporting arrays with dependencies', () => {
+    expect(`
+      define(['side-effect'], ['this', 'module', 'is', 'an', 'array']);
+    `).toBeTransformedTo(`
+      require('side-effect');
+      module.exports = ['this', 'module', 'is', 'an', 'array'];
+    `);
+  });
+
+  it('transforms non-function modules exporting primitives with no dependencies', () => {
+    const primitives = ["'a string'", '33', 'true', 'false', 'null', 'undefined'];
+    primitives.forEach((primitive) => {
+      expect(`
+        define(${primitive});
+      `).toBeTransformedTo(`
+        module.exports = ${primitive};
+      `);
+    });
+  });
+
+  it('handles non-function modules exporting primitives with dependencies', () => {
+    const primitives = ["'a string'", '33', 'true', 'false', 'null', 'undefined'];
+    primitives.forEach((primitive) => {
+      expect(`
+        define(['side-effect'], ${primitive});
+      `).toBeTransformedTo(`
+        require('side-effect');
+        module.exports = ${primitive};
+      `);
+    });
+  });
+
+  it('transforms non-function modules requiring `require` for some reason', () => {
+    expect(`
+      define(['require'], { some: 'stuff' });
+    `).toBeTransformedTo(`
+      module.exports = { some: 'stuff' };
+    `);
+  });
+
+  it('transforms non-function modules requiring `exports` for some reason', () => {
+    expect(`
+      define(['exports'], { some: 'stuff' });
+    `).toBeTransformedTo(`
+      module.exports = { some: 'stuff' };
+    `);
+  });
+
+  it('transforms non-function modules requiring `module` for some reason', () => {
+    expect(`
+      define(['module'], { some: 'stuff' });
+    `).toBeTransformedTo(`
+      module.exports = { some: 'stuff' };
+    `);
+  });
+
+  it('transforms named non-function modules with no dependencies', () => {
+    expect(`
+      define('auselessname', { thismodule: 'is an object' });
+    `).toBeTransformedTo(`
+      module.exports = { thismodule: 'is an object' };
+    `);
+  });
+
+  it('transforms named non-function modules with dependencies', () => {
+    expect(`
+      define('auselessname', ['side-effect'], { thismodule: 'is an object' });
+    `).toBeTransformedTo(`
+      require('side-effect');
+      module.exports = { thismodule: 'is an object' };
+    `);
+  });
 });


### PR DESCRIPTION
As described in #1. This implementation doesn't require the changes made in #4, and mainly just waits to check if the factory is a function in some places, and then exports whatever value it is if it's not a factory (even if it's a falsy value). I did some testing with requirejs, and it exports falsy values. For example:

```javascript
define('one', false);
define('two', '');
define('three', undefined);
define('four', null);

require(['one', 'two', 'three', 'four'], function(one, two, three, four) {
  console.log(one, two, three, four);
});
```

will output `false '' undefined null`. So I think it's no problem to just ignore whatever the factory is if it's not a function. 

@captbaritone if you have anything additional that builds on #4/#1 and would like to PR it, go ahead and we can consolidate/pick one of the implementations - planning to do some cleanup after #1 is closed, as there are some edge cases that I'd like to test (especially for require). The code in this PR is not 100% to my satisfaction, but the changes are relatively small and it seems to get the job done, so I'd like to try and get #1 closed.

Review @captbaritone 