### PR TITLE
Remove distracting code from readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module.exports = function() {
 Input:
 
 ```javascript
+// Nested requires
 require(['jquery', 'underscore', 'myModule'], function($, _) {
   // ...
   require(['anotherModule'], function(anotherModule) {

--- a/README.md
+++ b/README.md
@@ -24,56 +24,59 @@ Add the transform to your .babelrc:
 }
 ```
 
-Input (define):
+## Examples
+
+### Define
+
+Input:
 
 ```javascript
 define(['jquery', 'underscore', 'myModule'], function($, _) {
-  var $divs = $('div');
+  // ...
   return {
-    divs: _.filter($divs, function(div) {
-      return div.hasChildNodes();
-    });
+    // ...
   };
 });
 ```
 
-Output (define):
+Output:
 
 ```javascript
 module.exports = function() {
   var $ = require('jquery');
   var _ = require('underscore');
   require('myModule');
+  // ...
   return {
-    divs: _.filter($divs, function(div) {
-      return div.hasChildNodes();
-    });
+    // ...
   };
 }();
 ```
 
-Input (require):
+### Require
+
+Input:
 
 ```javascript
 require(['jquery', 'underscore', 'myModule'], function($, _) {
-  $(document).append($('<div>').text(_.random(10)));
+  // ...
   require(['anotherModule'], function(anotherModule) {
-    anotherModule.doSomeStuff(_.random(10));
+    // ...
   });
 });
 ```
 
-Output (require):
+Output:
 
 ```javascript
 (function() {
   var $ = require('jquery');
   var _ = require('underscore');
   require('myModule');
-  $(document).append($('<div>').text(_.random(10)));
+  // ...
   (function() {
     var anotherModule = require('anotherModule');
-    anotherModule.doSomeStuff(_.random(10));
+    // ...
   })();
 })();
 ```


### PR DESCRIPTION
I think the extra code in the examples was just obfuscating what the examples are really trying to illustrate. I've removed any unnecessary code from the main examples in this PR. 

New markdown can be found [here](https://github.com/msrose/babel-plugin-transform-amd-to-commonjs/blob/clean-up-readme-examples/README.md#examples). 

Does this look good to you @captbaritone, or do you think at least _some_ code (much simpler than what was previously there) might be better than `// ...` snips? Thanks in advance.