### PR TITLE
Use node environment in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/tests/setup.js",
-    "collectCoverageFrom": ["index.js"]
+    "collectCoverageFrom": ["index.js"],
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
JSDOM isn't used in the tests, so using the node environment should make
them run faster.