### PR TITLE
Refactor module/exports injection detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const EXPORTS = 'exports';
 const DEFINE = 'define';
 
 module.exports = ({ types: t }) => {
-  const decodeDefineArguments = (argNodes) => {
-    if(argNodes.length === 1) {
+  const decodeDefineArguments = argNodes => {
+    if (argNodes.length === 1) {
       return { factory: argNodes[0] };
-    } else if(argNodes.length === 2) {
+    } else if (argNodes.length === 2) {
       const decodedArgs = { factory: argNodes[1] };
-      if(t.isArrayExpression(argNodes[0])) {
+      if (t.isArrayExpression(argNodes[0])) {
         decodedArgs.dependencyList = argNodes[0];
       }
       return decodedArgs;
@@ -20,8 +20,8 @@ module.exports = ({ types: t }) => {
     }
   };
 
-  const decodeRequireArguments = (argNodes) => {
-    if(argNodes.length === 1) {
+  const decodeRequireArguments = argNodes => {
+    if (argNodes.length === 1) {
       return { dependencyList: argNodes[0] };
     } else {
       return { dependencyList: argNodes[0], factory: argNodes[1] };
@@ -33,13 +33,11 @@ module.exports = ({ types: t }) => {
     [REQUIRE]: decodeRequireArguments
   };
 
-  const createModuleExportsAssignmentExpression = (value) => {
+  const createModuleExportsAssignmentExpression = value => {
     return t.expressionStatement(
       t.assignmentExpression(
         '=',
-        t.memberExpression(
-          t.identifier(MODULE), t.identifier(EXPORTS)
-        ),
+        t.memberExpression(t.identifier(MODULE), t.identifier(EXPORTS)),
         value
       )
     );
@@ -47,16 +45,20 @@ module.exports = ({ types: t }) => {
 
   const createRequireExpression = (dependencyNode, variableName) => {
     const requireCall = t.callExpression(t.identifier(REQUIRE), [dependencyNode]);
-    if(variableName) {
+    if (variableName) {
       return t.variableDeclaration('var', [t.variableDeclarator(variableName, requireCall)]);
     } else {
       return t.expressionStatement(requireCall);
     }
   };
 
-  const isModuleOrExportsInDependencyList = (dependencyList) => {
-    return dependencyList && dependencyList.elements.some(element =>
-      t.isStringLiteral(element) && (element.value === MODULE || element.value === EXPORTS)
+  const isModuleOrExportsInDependencyList = dependencyList => {
+    return (
+      dependencyList &&
+      dependencyList.elements.some(
+        element =>
+          t.isStringLiteral(element) && (element.value === MODULE || element.value === EXPORTS)
+      )
     );
   };
 
@@ -65,8 +67,10 @@ module.exports = ({ types: t }) => {
   };
 
   const isModuleOrExportsInjected = (dependencyList, factoryArity) => {
-    return isModuleOrExportsInDependencyList(dependencyList) ||
-      isSimplifiedCommonJSWrapperWithModuleOrExports(dependencyList, factoryArity);
+    return (
+      isModuleOrExportsInDependencyList(dependencyList) ||
+      isSimplifiedCommonJSWrapperWithModuleOrExports(dependencyList, factoryArity)
+    );
   };
 
   // Simple version of zip that only pairs elements until the end of the first array
@@ -79,63 +83,70 @@ module.exports = ({ types: t }) => {
       ExpressionStatement(path) {
         const { node, parent } = path;
 
-        if(!t.isCallExpression(node.expression)) return;
+        if (!t.isCallExpression(node.expression)) return;
 
         const { name } = node.expression.callee;
         const isDefineCall = name === DEFINE;
 
-        if(isDefineCall && !t.isProgram(parent)) return;
+        if (isDefineCall && !t.isProgram(parent)) return;
 
         const argumentDecoder = argumentDecoders[name];
 
-        if(!argumentDecoder) return;
+        if (!argumentDecoder) return;
 
         const { dependencyList, factory } = argumentDecoder(node.expression.arguments);
 
-        if(!t.isArrayExpression(dependencyList) && !factory) return;
+        if (!t.isArrayExpression(dependencyList) && !factory) return;
 
         const isFunctionFactory = t.isFunctionExpression(factory);
         const requireExpressions = [];
         // Order is important here for the simplified commonjs wrapper
         const keywords = [REQUIRE, EXPORTS, MODULE];
 
-        if(dependencyList) {
+        if (dependencyList) {
           const dependencyParameterPairs = zip(
             dependencyList.elements,
             isFunctionFactory ? factory.params : []
           );
 
-          const explicitRequires = dependencyParameterPairs.filter(([dependency]) => {
-            return !t.isStringLiteral(dependency) || keywords.indexOf(dependency.value) === -1;
-          }).map(([dependency, paramName]) => {
-            return createRequireExpression(dependency, paramName);
-          });
+          const explicitRequires = dependencyParameterPairs
+            .filter(([dependency]) => {
+              return !t.isStringLiteral(dependency) || keywords.indexOf(dependency.value) === -1;
+            })
+            .map(([dependency, paramName]) => {
+              return createRequireExpression(dependency, paramName);
+            });
 
           requireExpressions.push(...explicitRequires);
         }
 
-        if(isFunctionFactory) {
+        if (isFunctionFactory) {
           const factoryArity = factory.params.length;
-          let replacementFuncExpr = t.functionExpression(null, [], t.blockStatement(
-            requireExpressions.concat(factory.body.body)
-          ));
+          let replacementFuncExpr = t.functionExpression(
+            null,
+            [],
+            t.blockStatement(requireExpressions.concat(factory.body.body))
+          );
           let replacementCallExprParams = [];
 
           // https://github.com/requirejs/requirejs/wiki/differences-between-the-simplified-commonjs-wrapper-and-standard-amd-define
           const isSimplifiedCommonJSWrapper = !dependencyList && factoryArity > 0;
-          if(isSimplifiedCommonJSWrapper) {
+          if (isSimplifiedCommonJSWrapper) {
             replacementFuncExpr = factory;
             replacementCallExprParams = keywords.slice(0, factoryArity).map(a => t.identifier(a));
           }
 
-          const factoryReplacement = t.callExpression(replacementFuncExpr, replacementCallExprParams);
+          const factoryReplacement = t.callExpression(
+            replacementFuncExpr,
+            replacementCallExprParams
+          );
 
-          if(isDefineCall && !isModuleOrExportsInjected(dependencyList, factoryArity)) {
+          if (isDefineCall && !isModuleOrExportsInjected(dependencyList, factoryArity)) {
             path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
           } else {
             path.replaceWith(factoryReplacement);
           }
-        } else if(factory && isDefineCall) {
+        } else if (factory && isDefineCall) {
           const exportExpression = createModuleExportsAssignmentExpression(factory);
           const nodes = requireExpressions.concat(exportExpression);
           path.replaceWithMultiple(nodes);

--- a/index.js
+++ b/index.js
@@ -54,15 +54,19 @@ module.exports = ({ types: t }) => {
     }
   };
 
+  const isModuleOrExportsInDependencyList = (dependencyList) => {
+    return dependencyList && dependencyList.elements.some(element =>
+      t.isStringLiteral(element) && (element.value === MODULE || element.value === EXPORTS)
+    );
+  };
+
+  const isSimplifiedCommonJSWrapperWithModuleOrExports = (dependencyList, factoryArity) => {
+    return !dependencyList && factoryArity > 1;
+  };
+
   const isModuleOrExportsInjected = (dependencyList, factoryArity) => {
-    if(dependencyList) {
-      return dependencyList.elements.some(element =>
-        t.isStringLiteral(element) && (element.value === MODULE || element.value === EXPORTS)
-      );
-    } else {
-      // Check if we have the simplified commonjs wrapper with more than just 'require' injected
-      return factoryArity > 1;
-    }
+    return isModuleOrExportsInDependencyList(dependencyList) ||
+      isSimplifiedCommonJSWrapperWithModuleOrExports(dependencyList, factoryArity);
   };
 
   // Simple version of zip that only pairs elements until the end of the first array

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const EXPORTS = 'exports';
 const DEFINE = 'define';
 
 module.exports = ({ types: t }) => {
-  const decodeDefineArguments = argNodes => {
-    if (argNodes.length === 1) {
+  const decodeDefineArguments = (argNodes) => {
+    if(argNodes.length === 1) {
       return { factory: argNodes[0] };
-    } else if (argNodes.length === 2) {
+    } else if(argNodes.length === 2) {
       const decodedArgs = { factory: argNodes[1] };
-      if (t.isArrayExpression(argNodes[0])) {
+      if(t.isArrayExpression(argNodes[0])) {
         decodedArgs.dependencyList = argNodes[0];
       }
       return decodedArgs;
@@ -20,8 +20,8 @@ module.exports = ({ types: t }) => {
     }
   };
 
-  const decodeRequireArguments = argNodes => {
-    if (argNodes.length === 1) {
+  const decodeRequireArguments = (argNodes) => {
+    if(argNodes.length === 1) {
       return { dependencyList: argNodes[0] };
     } else {
       return { dependencyList: argNodes[0], factory: argNodes[1] };
@@ -33,11 +33,13 @@ module.exports = ({ types: t }) => {
     [REQUIRE]: decodeRequireArguments
   };
 
-  const createModuleExportsAssignmentExpression = value => {
+  const createModuleExportsAssignmentExpression = (value) => {
     return t.expressionStatement(
       t.assignmentExpression(
         '=',
-        t.memberExpression(t.identifier(MODULE), t.identifier(EXPORTS)),
+        t.memberExpression(
+          t.identifier(MODULE), t.identifier(EXPORTS)
+        ),
         value
       )
     );
@@ -45,11 +47,27 @@ module.exports = ({ types: t }) => {
 
   const createRequireExpression = (dependencyNode, variableName) => {
     const requireCall = t.callExpression(t.identifier(REQUIRE), [dependencyNode]);
-    if (variableName) {
+    if(variableName) {
       return t.variableDeclaration('var', [t.variableDeclarator(variableName, requireCall)]);
     } else {
       return t.expressionStatement(requireCall);
     }
+  };
+
+  const isModuleOrExportsInjected = (dependencyList, factoryArity) => {
+    if(dependencyList) {
+      return dependencyList.elements.some(element =>
+        t.isStringLiteral(element) && (element.value === MODULE || element.value === EXPORTS)
+      );
+    } else {
+      // Check if we have the simplified commonjs wrapper with more than just 'require' injected
+      return factoryArity > 1;
+    }
+  };
+
+  // Simple version of zip that only pairs elements until the end of the first array
+  const zip = (array1, array2) => {
+    return array1.map((element, index) => [element, array2[index]]);
   };
 
   return {
@@ -57,73 +75,63 @@ module.exports = ({ types: t }) => {
       ExpressionStatement(path) {
         const { node, parent } = path;
 
-        if (!t.isCallExpression(node.expression)) return;
+        if(!t.isCallExpression(node.expression)) return;
 
         const { name } = node.expression.callee;
         const isDefineCall = name === DEFINE;
 
-        if (isDefineCall && !t.isProgram(parent)) return;
+        if(isDefineCall && !t.isProgram(parent)) return;
 
         const argumentDecoder = argumentDecoders[name];
 
-        if (!argumentDecoder) return;
+        if(!argumentDecoder) return;
 
         const { dependencyList, factory } = argumentDecoder(node.expression.arguments);
 
-        if (!t.isArrayExpression(dependencyList) && !factory) return;
+        if(!t.isArrayExpression(dependencyList) && !factory) return;
 
-        let injectsModuleOrExports = false;
         const isFunctionFactory = t.isFunctionExpression(factory);
         const requireExpressions = [];
+        // Order is important here for the simplified commonjs wrapper
+        const keywords = [REQUIRE, EXPORTS, MODULE];
 
-        if (dependencyList) {
-          dependencyList.elements.forEach((el, i) => {
-            if (t.isStringLiteral(el)) {
-              switch (el.value) {
-                case REQUIRE:
-                  return;
-                case MODULE:
-                case EXPORTS:
-                  injectsModuleOrExports = true;
-                  return;
-              }
-            }
-            const paramName = isFunctionFactory && factory.params[i];
-            requireExpressions.push(createRequireExpression(el, paramName));
+        if(dependencyList) {
+          const dependencyParameterPairs = zip(
+            dependencyList.elements,
+            isFunctionFactory ? factory.params : []
+          );
+
+          const explicitRequires = dependencyParameterPairs.filter(([dependency]) => {
+            return !t.isStringLiteral(dependency) || keywords.indexOf(dependency.value) === -1;
+          }).map(([dependency, paramName]) => {
+            return createRequireExpression(dependency, paramName);
           });
+
+          requireExpressions.push(...explicitRequires);
         }
 
-        if (isFunctionFactory) {
+        if(isFunctionFactory) {
           const factoryArity = factory.params.length;
-          let replacementFuncExpr = t.functionExpression(
-            null,
-            [],
-            t.blockStatement(requireExpressions.concat(factory.body.body))
-          );
+          let replacementFuncExpr = t.functionExpression(null, [], t.blockStatement(
+            requireExpressions.concat(factory.body.body)
+          ));
           let replacementCallExprParams = [];
 
           // https://github.com/requirejs/requirejs/wiki/differences-between-the-simplified-commonjs-wrapper-and-standard-amd-define
           const isSimplifiedCommonJSWrapper = !dependencyList && factoryArity > 0;
-          if (isSimplifiedCommonJSWrapper) {
+          if(isSimplifiedCommonJSWrapper) {
             replacementFuncExpr = factory;
-            const identifiers = [REQUIRE, EXPORTS, MODULE];
-            replacementCallExprParams = identifiers
-              .slice(0, factoryArity)
-              .map(a => t.identifier(a));
+            replacementCallExprParams = keywords.slice(0, factoryArity).map(a => t.identifier(a));
           }
 
-          const factoryReplacement = t.callExpression(
-            replacementFuncExpr,
-            replacementCallExprParams
-          );
+          const factoryReplacement = t.callExpression(replacementFuncExpr, replacementCallExprParams);
 
-          injectsModuleOrExports = injectsModuleOrExports || (!dependencyList && factoryArity > 1);
-          if (isDefineCall && !injectsModuleOrExports) {
+          if(isDefineCall && !isModuleOrExportsInjected(dependencyList, factoryArity)) {
             path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
           } else {
             path.replaceWith(factoryReplacement);
           }
-        } else if (factory && isDefineCall) {
+        } else if(factory && isDefineCall) {
           const exportExpression = createModuleExportsAssignmentExpression(factory);
           const nodes = requireExpressions.concat(exportExpression);
           path.replaceWithMultiple(nodes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1519,11 +1519,30 @@
         "eslint-plugin-react": "7.2.1"
       }
     },
+    "eslint-config-prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz",
+      "integrity": "sha1-t1seq+oMi5ezRANkfuJds0m52KA=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "5.0.1"
+      }
+    },
     "eslint-plugin-jest": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz",
       "integrity": "sha1-7BXrpqwKtEpn6/bgJnLKnX58uik=",
       "dev": true
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.2.0.tgz",
+      "integrity": "sha512-LmIOP99A+BMeMYZoDeU196cV7FNIHJEjjWLARdz6JSTYmGK+HTEAVbJukPr/ZVOKPs5Hf7b10aXwSbty6Gqqsw==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.1",
+        "jest-docblock": "20.0.3"
+      }
     },
     "eslint-plugin-react": {
       "version": "7.2.1",
@@ -1665,6 +1684,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.1.tgz",
+      "integrity": "sha1-CuoOTmBbaiGJ8Ok21Lf7rxt8/Zs=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2773,6 +2798,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "getpass": {
@@ -4372,6 +4403,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.6.1.tgz",
+      "integrity": "sha512-f85qBoQiqiFM/sCmJaN4Lagj9bqMcv38vCftqp4GfVessAqq3Ns6g+3gd8UXReStLLE/DGEdwiZXoFKxphKqwg==",
       "dev": true
     },
     "pretty-format": {


### PR DESCRIPTION
Basically there was this nasty switch case that was setting a boolean early on in the file that was used later on in the file, and it was less than pretty. I've refactored the switch case and removed the need for the boolean by extracting a helper function for detecting if module/exports are injected into an AMD module. This means there's an extra iteration through the dependency list, but the performance impact of that is negligible.

I'll make another PR soon to move the helper functions to another file, since the current file is getting a bit big. That will require a directory restructure to keep the prepublish step simple, so no point in doing it as part of this PR.

@captbaritone your review would be very valuable, especially for variable naming and comment clarity (and of course anything else you'd like to contribute).