### PR TITLE
Check return value of define factory before setting module.exports

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,5 +4,6 @@ module.exports = {
   REQUIRE: 'require',
   MODULE: 'module',
   EXPORTS: 'exports',
-  DEFINE: 'define'
+  DEFINE: 'define',
+  AMD_DEFINE_RESULT: 'amdDefineResult'
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,6 +37,25 @@ module.exports = ({ types: t }) => {
     );
   };
 
+  const RESULT_CHECK = t.expressionStatement(
+    t.logicalExpression(
+      '&&',
+      t.binaryExpression(
+        '!==',
+        t.unaryExpression('typeof', t.identifier('amdDefineResult')),
+        t.stringLiteral('undefined')
+      ),
+      createModuleExportsAssignmentExpression(t.identifier('amdDefineResult')).expression
+    )
+  );
+
+  const createModuleExportsResultCheckExpression = value => {
+    return [
+      t.variableDeclaration('var', [t.variableDeclarator(t.identifier('amdDefineResult'), value)]),
+      RESULT_CHECK
+    ];
+  };
+
   const createRequireExpression = (dependencyNode, variableName) => {
     const requireCall = t.callExpression(t.identifier(REQUIRE), [dependencyNode]);
     if (variableName) {
@@ -71,6 +90,7 @@ module.exports = ({ types: t }) => {
     decodeDefineArguments,
     decodeRequireArguments,
     createModuleExportsAssignmentExpression,
+    createModuleExportsResultCheckExpression,
     createRequireExpression,
     isModuleOrExportsInjected
   };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,22 +37,20 @@ module.exports = ({ types: t }) => {
     );
   };
 
-  const RESULT_CHECK = t.expressionStatement(
-    t.logicalExpression(
-      '&&',
-      t.binaryExpression(
-        '!==',
-        t.unaryExpression('typeof', t.identifier('amdDefineResult')),
-        t.stringLiteral('undefined')
-      ),
-      createModuleExportsAssignmentExpression(t.identifier('amdDefineResult')).expression
-    )
-  );
-
-  const createModuleExportsResultCheckExpression = value => {
+  const createModuleExportsResultCheck = (value, identifier) => {
     return [
-      t.variableDeclaration('var', [t.variableDeclarator(t.identifier('amdDefineResult'), value)]),
-      RESULT_CHECK
+      t.variableDeclaration('var', [t.variableDeclarator(identifier, value)]),
+      t.expressionStatement(
+        t.logicalExpression(
+          '&&',
+          t.binaryExpression(
+            '!==',
+            t.unaryExpression('typeof', identifier),
+            t.stringLiteral('undefined')
+          ),
+          createModuleExportsAssignmentExpression(identifier).expression
+        )
+      )
     ];
   };
 
@@ -90,7 +88,7 @@ module.exports = ({ types: t }) => {
     decodeDefineArguments,
     decodeRequireArguments,
     createModuleExportsAssignmentExpression,
-    createModuleExportsResultCheckExpression,
+    createModuleExportsResultCheck,
     createRequireExpression,
     isModuleOrExportsInjected
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { REQUIRE, MODULE, EXPORTS, DEFINE } = require('./constants');
+const { REQUIRE, MODULE, EXPORTS, DEFINE, AMD_DEFINE_RESULT } = require('./constants');
 const createHelpers = require('./helpers');
 
 module.exports = ({ types: t }) => {
@@ -10,7 +10,7 @@ module.exports = ({ types: t }) => {
     isModuleOrExportsInjected,
     createRequireExpression,
     createModuleExportsAssignmentExpression,
-    createModuleExportsResultCheckExpression
+    createModuleExportsResultCheck
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -85,7 +85,14 @@ module.exports = ({ types: t }) => {
         if (!isModuleOrExportsInjected(dependencyList, factoryArity)) {
           path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
         } else {
-          path.replaceWithMultiple(createModuleExportsResultCheckExpression(factoryReplacement));
+          path.replaceWithMultiple(
+            createModuleExportsResultCheck(
+              factoryReplacement,
+              path.scope.hasOwnBinding(AMD_DEFINE_RESULT)
+                ? path.scope.generateUidIdentifier(AMD_DEFINE_RESULT)
+                : t.identifier(AMD_DEFINE_RESULT)
+            )
+          );
         }
       } else {
         path.replaceWith(factoryReplacement);

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ module.exports = ({ types: t }) => {
     decodeRequireArguments,
     isModuleOrExportsInjected,
     createRequireExpression,
-    createModuleExportsAssignmentExpression
+    createModuleExportsAssignmentExpression,
+    createModuleExportsResultCheckExpression
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -80,8 +81,12 @@ module.exports = ({ types: t }) => {
 
       const factoryReplacement = t.callExpression(replacementFuncExpr, replacementCallExprParams);
 
-      if (isDefineCall && !isModuleOrExportsInjected(dependencyList, factoryArity)) {
-        path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
+      if (isDefineCall) {
+        if (!isModuleOrExportsInjected(dependencyList, factoryArity)) {
+          path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
+        } else {
+          path.replaceWithMultiple(createModuleExportsResultCheckExpression(factoryReplacement));
+        }
       } else {
         path.replaceWith(factoryReplacement);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -85,13 +85,11 @@ module.exports = ({ types: t }) => {
         if (!isModuleOrExportsInjected(dependencyList, factoryArity)) {
           path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
         } else {
+          const resultCheckIdentifier = path.scope.hasOwnBinding(AMD_DEFINE_RESULT)
+            ? path.scope.generateUidIdentifier(AMD_DEFINE_RESULT)
+            : t.identifier(AMD_DEFINE_RESULT);
           path.replaceWithMultiple(
-            createModuleExportsResultCheck(
-              factoryReplacement,
-              path.scope.hasOwnBinding(AMD_DEFINE_RESULT)
-                ? path.scope.generateUidIdentifier(AMD_DEFINE_RESULT)
-                : t.identifier(AMD_DEFINE_RESULT)
-            )
+            createModuleExportsResultCheck(factoryReplacement, resultCheckIdentifier)
           );
         }
       } else {

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -147,28 +147,37 @@ describe('Plugin for define blocks', () => {
     `);
   });
 
+  const checkAmdDefineResult = value => `
+    var amdDefineResult = ${value};
+    typeof amdDefineResult !== 'undefined' && (module.exports = amdDefineResult);
+  `;
+
   it('handles injection of a dependency named `module`', () => {
     expect(`
       define(['module'], function(module) {
         module.exports = { hey: 'boi' };
       });
-    `).toBeTransformedTo(`
-      (function() {
-        module.exports = { hey: 'boi' };
-      })();
-    `);
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        function() {
+          module.exports = { hey: 'boi' };
+        }()
+      `)
+    );
   });
 
-  it('handles injection of dependency name `exports`', () => {
+  it('handles injection of dependency named `exports`', () => {
     expect(`
       define(['exports'], function(exports) {
         exports.hey = 'boi';
       });
-    `).toBeTransformedTo(`
-      (function() {
-        exports.hey = 'boi';
-      })();
-    `);
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        function() {
+          exports.hey = 'boi';
+        }()
+      `)
+    );
   });
 
   it('transforms the simplified commonjs wrapper', () => {
@@ -177,23 +186,27 @@ describe('Plugin for define blocks', () => {
         var stuff = require('hi');
         exports.hey = stuff.boi;
       });
-    `).toBeTransformedTo(`
-      (function(require, exports, module) {
-        var stuff = require('hi');
-        exports.hey = stuff.boi;
-      })(require, exports, module);
-    `);
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        (function(require, exports, module) {
+          var stuff = require('hi');
+          exports.hey = stuff.boi;
+        })(require, exports, module)
+      `)
+    );
     expect(`
       define(function(require, exports) {
         var stuff = require('hi');
         exports.hey = stuff.boi;
       });
-    `).toBeTransformedTo(`
-      (function(require, exports) {
-        var stuff = require('hi');
-        exports.hey = stuff.boi;
-      })(require, exports);
-    `);
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        (function(require, exports) {
+          var stuff = require('hi');
+          exports.hey = stuff.boi;
+        })(require, exports)
+      `)
+    );
     expect(`
       define(function(require) {
         var stuff = require('hi');
@@ -213,23 +226,27 @@ describe('Plugin for define blocks', () => {
         var stuff = llamas('hi');
         cows.hey = stuff.boi;
       });
-    `).toBeTransformedTo(`
-      (function(llamas, cows, bears) {
-        var stuff = llamas('hi');
-        cows.hey = stuff.boi;
-      })(require, exports, module);
-    `);
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        (function(llamas, cows, bears) {
+          var stuff = llamas('hi');
+          cows.hey = stuff.boi;
+        })(require, exports, module)
+      `)
+    );
     expect(`
       define(function(llamas, cows) {
         var stuff = llamas('hi');
         cows.hey = stuff.boi;
       });
-    `).toBeTransformedTo(`
-      (function(llamas, cows) {
-        var stuff = llamas('hi');
-        cows.hey = stuff.boi;
-      })(require, exports);
-    `);
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        (function(llamas, cows) {
+          var stuff = llamas('hi');
+          cows.hey = stuff.boi;
+        })(require, exports)
+      `)
+    );
     expect(`
       define(function(donkeys) {
         var stuff = donkeys('hi');


### PR DESCRIPTION
This PR takes care of the behaviour described at the [end of the readme](https://github.com/msrose/babel-plugin-transform-amd-to-commonjs#injecting-require-module-or-exports-as-dependencies) on master. 

There's no pressing reason to address this; I just want to do it for complete correctness. 

I remember seeing webpack taking care of AMD by doing a check like this on the return value of the factory function, so that offers a bit of validation on the strategy used.

I've chosen to use babel's utilities for generating unique variables in scope for creating the temporary variable used. The other option is wrapping everything in another IIFE but since that adds up to one extra function call per modue at runtime, I figured generating a unique variable at compile time is a better option.

It's possible to use this pattern for every single transformation made, but doing it on a need-only basis makes updating the test suite easier. Also the output is a bit more understandable without the extra code in there, which makes debugging easier.

@captbaritone I'd appreciate your review for this. I'd also like to release a 1.0.0 after this gets merged - is there anything else you think we should take care of before doing that?