### PR TITLE
Code simplification

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -69,8 +69,13 @@ module.exports = ({ types: t }) => {
     );
   };
 
+  // https://github.com/requirejs/requirejs/wiki/differences-between-the-simplified-commonjs-wrapper-and-standard-amd-define
+  const isSimplifiedCommonJSWrapper = (dependencyList, factoryArity) => {
+    return !dependencyList && factoryArity > 0;
+  };
+
   const isSimplifiedCommonJSWrapperWithModuleOrExports = (dependencyList, factoryArity) => {
-    return !dependencyList && factoryArity > 1;
+    return isSimplifiedCommonJSWrapper(dependencyList, factoryArity) && factoryArity > 1;
   };
 
   const isModuleOrExportsInjected = (dependencyList, factoryArity) => {
@@ -86,6 +91,7 @@ module.exports = ({ types: t }) => {
     createModuleExportsAssignmentExpression,
     createModuleExportsResultCheck,
     createRequireExpression,
+    isSimplifiedCommonJSWrapper,
     isModuleOrExportsInjected
   };
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,11 +20,7 @@ module.exports = ({ types: t }) => {
   };
 
   const decodeRequireArguments = argNodes => {
-    if (argNodes.length === 1) {
-      return { dependencyList: argNodes[0] };
-    } else {
-      return { dependencyList: argNodes[0], factory: argNodes[1] };
-    }
+    return { dependencyList: argNodes[0], factory: argNodes[1] };
   };
 
   const createModuleExportsAssignmentExpression = value => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -85,6 +85,10 @@ module.exports = ({ types: t }) => {
     );
   };
 
+  const getUniqueIdentifier = (scope, name) => {
+    return scope.hasOwnBinding(name) ? scope.generateUidIdentifier(name) : t.identifier(name);
+  };
+
   return {
     decodeDefineArguments,
     decodeRequireArguments,
@@ -92,6 +96,7 @@ module.exports = ({ types: t }) => {
     createModuleExportsResultCheck,
     createRequireExpression,
     isSimplifiedCommonJSWrapper,
-    isModuleOrExportsInjected
+    isModuleOrExportsInjected,
+    getUniqueIdentifier
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ module.exports = ({ types: t }) => {
     isSimplifiedCommonJSWrapper,
     createRequireExpression,
     createModuleExportsAssignmentExpression,
-    createModuleExportsResultCheck
+    createModuleExportsResultCheck,
+    getUniqueIdentifier
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -84,9 +85,7 @@ module.exports = ({ types: t }) => {
         if (!isModuleOrExportsInjected(dependencyList, factoryArity)) {
           path.replaceWith(createModuleExportsAssignmentExpression(factoryReplacement));
         } else {
-          const resultCheckIdentifier = path.scope.hasOwnBinding(AMD_DEFINE_RESULT)
-            ? path.scope.generateUidIdentifier(AMD_DEFINE_RESULT)
-            : t.identifier(AMD_DEFINE_RESULT);
+          const resultCheckIdentifier = getUniqueIdentifier(path.scope, AMD_DEFINE_RESULT);
           path.replaceWithMultiple(
             createModuleExportsResultCheck(factoryReplacement, resultCheckIdentifier)
           );

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ module.exports = ({ types: t }) => {
 
       const explicitRequires = dependencyParameterPairs
         .filter(([dependency]) => {
-          return !t.isStringLiteral(dependency) || keywords.indexOf(dependency.value) === -1;
+          return !t.isStringLiteral(dependency) || !keywords.includes(dependency.value);
         })
         .map(([dependency, paramName]) => {
           return createRequireExpression(dependency, paramName);

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ module.exports = ({ types: t }) => {
     decodeDefineArguments,
     decodeRequireArguments,
     isModuleOrExportsInjected,
+    isSimplifiedCommonJSWrapper,
     createRequireExpression,
     createModuleExportsAssignmentExpression,
     createModuleExportsResultCheck
@@ -72,9 +73,7 @@ module.exports = ({ types: t }) => {
       );
       let replacementCallExprParams = [];
 
-      // https://github.com/requirejs/requirejs/wiki/differences-between-the-simplified-commonjs-wrapper-and-standard-amd-define
-      const isSimplifiedCommonJSWrapper = !dependencyList && factoryArity > 0;
-      if (isSimplifiedCommonJSWrapper) {
+      if (isSimplifiedCommonJSWrapper(dependencyList, factoryArity)) {
         replacementFuncExpr = factory;
         replacementCallExprParams = keywords.slice(0, factoryArity).map(a => t.identifier(a));
       }


### PR DESCRIPTION
- Extract helper function for checking for simplified commonjs wrapper
- Simplify helper function for decoding require arguments
- Use includes since support for Node.js 4 was dropped
- Extract helper function for getting unique identifier