### PR TITLE
Test for ignoring require non-function factories

### DIFF
--- a/tests/require.test.js
+++ b/tests/require.test.js
@@ -121,4 +121,14 @@ describe('Plugin for require blocks', () => {
       })();
     `);
   });
+
+  it('ignores non-function factories', () => {
+    expect(`
+      require(['sup', 'dawg', 'hi'], { nonFunction: 'factory' });
+    `).toBeTransformedTo(`
+      require('sup');
+      require('dawg');
+      require('hi');
+    `);
+  });
 });


### PR DESCRIPTION
Makes sure that non-function factories are only transformed for define calls. There's an existing condition that checks if a define call is being transformed that isn't being tested - it could be removed and no tests would fail so writing this test to fill in the gap.