### PR TITLE
Convert AMD syntax using arrow functions

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -93,7 +93,7 @@ module.exports = ({ types: t }) => {
     return t.isFunctionExpression(factory) || t.isArrowFunctionExpression(factory);
   };
 
-  const createFunctionExpression = (factory, requireExpressions) => {
+  const createFactoryReplacementExpression = (factory, requireExpressions) => {
     if (t.isFunctionExpression(factory)) {
       return t.functionExpression(
         null,
@@ -110,8 +110,7 @@ module.exports = ({ types: t }) => {
     }
     return t.arrowFunctionExpression(
       [],
-      t.blockStatement(requireExpressions.concat(bodyStatement)),
-      false
+      t.blockStatement(requireExpressions.concat(bodyStatement))
     );
   };
 
@@ -125,6 +124,6 @@ module.exports = ({ types: t }) => {
     isModuleOrExportsInjected,
     getUniqueIdentifier,
     isFunctionExpression,
-    createFunctionExpression
+    createFactoryReplacementExpression
   };
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -89,6 +89,10 @@ module.exports = ({ types: t }) => {
     return scope.hasOwnBinding(name) ? scope.generateUidIdentifier(name) : t.identifier(name);
   };
 
+  const isFunctionExpression = factory => {
+    return t.isFunctionExpression(factory) || t.isArrowFunctionExpression(factory);
+  };
+
   return {
     decodeDefineArguments,
     decodeRequireArguments,
@@ -97,6 +101,7 @@ module.exports = ({ types: t }) => {
     createRequireExpression,
     isSimplifiedCommonJSWrapper,
     isModuleOrExportsInjected,
-    getUniqueIdentifier
+    getUniqueIdentifier,
+    isFunctionExpression
   };
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -93,6 +93,28 @@ module.exports = ({ types: t }) => {
     return t.isFunctionExpression(factory) || t.isArrowFunctionExpression(factory);
   };
 
+  const createFunctionExpression = (factory, requireExpressions) => {
+    if (t.isFunctionExpression(factory)) {
+      return t.functionExpression(
+        null,
+        [],
+        t.blockStatement(requireExpressions.concat(factory.body.body))
+      );
+    }
+    let bodyStatement;
+    if (t.isBlockStatement(factory.body)) {
+      bodyStatement = factory.body.body;
+    } else {
+      // implicit return arrow function
+      bodyStatement = t.returnStatement(factory.body);
+    }
+    return t.arrowFunctionExpression(
+      [],
+      t.blockStatement(requireExpressions.concat(bodyStatement)),
+      false
+    );
+  };
+
   return {
     decodeDefineArguments,
     decodeRequireArguments,
@@ -102,6 +124,7 @@ module.exports = ({ types: t }) => {
     isSimplifiedCommonJSWrapper,
     isModuleOrExportsInjected,
     getUniqueIdentifier,
-    isFunctionExpression
+    isFunctionExpression,
+    createFunctionExpression
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = ({ types: t }) => {
     createModuleExportsResultCheck,
     getUniqueIdentifier,
     isFunctionExpression,
-    createFunctionExpression
+    createFactoryReplacementExpression
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -69,7 +69,7 @@ module.exports = ({ types: t }) => {
 
     if (isFunctionFactory) {
       const factoryArity = factory.params.length;
-      let replacementFuncExpr = createFunctionExpression(factory, requireExpressions);
+      let replacementFuncExpr = createFactoryReplacementExpression(factory, requireExpressions);
       let replacementCallExprParams = [];
 
       if (isSimplifiedCommonJSWrapper(dependencyList, factoryArity)) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ module.exports = ({ types: t }) => {
     createRequireExpression,
     createModuleExportsAssignmentExpression,
     createModuleExportsResultCheck,
-    getUniqueIdentifier
+    getUniqueIdentifier,
+    isFunctionExpression
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -43,7 +44,7 @@ module.exports = ({ types: t }) => {
 
     if (!t.isArrayExpression(dependencyList) && !factory) return;
 
-    const isFunctionFactory = t.isFunctionExpression(factory);
+    const isFunctionFactory = isFunctionExpression(factory);
     const requireExpressions = [];
     // Order is important here for the simplified commonjs wrapper
     const keywords = [REQUIRE, EXPORTS, MODULE];

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ module.exports = ({ types: t }) => {
     createModuleExportsAssignmentExpression,
     createModuleExportsResultCheck,
     getUniqueIdentifier,
-    isFunctionExpression
+    isFunctionExpression,
+    createFunctionExpression
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -68,11 +69,7 @@ module.exports = ({ types: t }) => {
 
     if (isFunctionFactory) {
       const factoryArity = factory.params.length;
-      let replacementFuncExpr = t.functionExpression(
-        null,
-        [],
-        t.blockStatement(requireExpressions.concat(factory.body.body))
-      );
+      let replacementFuncExpr = createFunctionExpression(factory, requireExpressions);
       let replacementCallExprParams = [];
 
       if (isSimplifiedCommonJSWrapper(dependencyList, factoryArity)) {

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -1,0 +1,319 @@
+'use strict';
+
+const { AMD_DEFINE_RESULT } = require('../src/constants');
+
+describe('Plugin for define blocks', () => {
+  it('transforms anonymous define blocks with one dependency', () => {
+    expect(`
+      define(['stuff'], (donkeys) => {
+        return {
+          llamas: donkeys.version
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var donkeys = require('stuff');
+        return {
+          llamas: donkeys.version
+        };
+      }();
+    `);
+  });
+
+  it('transforms anonymous define blocks with multiple dependencies', () => {
+    expect(`
+      define(['stuff', 'here'], (donkeys, aruba) => {
+        return {
+           llamas: donkeys.version,
+           cows: aruba.hi
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var donkeys = require('stuff');
+        var aruba = require('here');
+        return {
+          llamas: donkeys.version,
+          cows: aruba.hi
+        };
+      }();
+    `);
+  });
+
+  it('transforms anonymous define blocks with unused dependencies', () => {
+    expect(`
+      define(['stuff', 'here'], (donkeys) => {
+        return {
+           llamas: donkeys.version
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var donkeys = require('stuff');
+        require('here');
+        return {
+          llamas: donkeys.version
+        };
+      }();
+    `);
+  });
+
+  it('only transforms define blocks at the top level', () => {
+    const program = `
+      if(someDumbCondition) {
+        define(['stuff'], (stuff) => {
+          return { hi: 'world' };
+        });
+      }
+    `;
+    expect(program).toBeTransformedTo(program);
+  });
+
+  it('transforms anonymous define blocks with no dependency list', () => {
+    expect(`
+      define(() => {
+        return {
+           llamas: 'donkeys'
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        return {
+          llamas: 'donkeys'
+        };
+      }();
+    `);
+  });
+
+  it('transforms dependencies listed as variables', () => {
+    expect(`
+      var dependency = 'hey';
+      define([dependency], (here) => {
+        return {
+           llamas: here.hi
+        };
+      });
+    `).toBeTransformedTo(`
+      var dependency = 'hey';
+      module.exports = function() {
+        var here = require(dependency);
+        return {
+          llamas: here.hi
+        };
+      }();
+    `);
+  });
+
+  it('transforms named define blocks with dependencies', () => {
+    expect(`
+      define('thismoduletho', ['hi'], (here) => {
+        return {
+           llamas: here.hi
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var here = require('hi');
+        return {
+          llamas: here.hi
+        };
+      }();
+    `);
+  });
+
+  it('transforms named define blocks with no dependency list', () => {
+    expect(`
+      define('thismoduletho', () => {
+        return {
+           llamas: 'they are fluffy'
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        return {
+          llamas: 'they are fluffy'
+        };
+      }();
+    `);
+  });
+
+  it('does not require a dependency named `require`', () => {
+    expect(`
+      define(['require'], (require) => {
+        var x = require('x');
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var x = require('x');
+      }();
+    `);
+  });
+
+  const checkAmdDefineResult = (value, identifier = AMD_DEFINE_RESULT) => `
+    var ${identifier} = ${value};
+    typeof ${identifier} !== 'undefined' && (module.exports = ${identifier});
+  `;
+
+  it('handles injection of a dependency named `module`', () => {
+    expect(`
+      define(['module'], (module) => {
+        module.exports = { hey: 'boi' };
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        function() {
+          module.exports = { hey: 'boi' };
+        }()
+      `)
+    );
+  });
+
+  it('handles injection of dependency named `exports`', () => {
+    expect(`
+      define(['exports'], (exports) => {
+        exports.hey = 'boi';
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        function() {
+          exports.hey = 'boi';
+        }()
+      `)
+    );
+  });
+
+  it('transforms the simplified commonjs wrapper', () => {
+    expect(`
+      define((require, exports, module) => {
+        var stuff = require('hi');
+        exports.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        ((require, exports, module) => {
+          var stuff = require('hi');
+          exports.hey = stuff.boi;
+        })(require, exports, module)
+      `)
+    );
+    expect(`
+      define((require, exports) => {
+        var stuff = require('hi');
+        exports.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        ((require, exports) => {
+          var stuff = require('hi');
+          exports.hey = stuff.boi;
+        })(require, exports)
+      `)
+    );
+    expect(`
+      define((require) => {
+        var stuff = require('hi');
+        exports.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(`
+      module.exports = ((require) => {
+        var stuff = require('hi');
+        exports.hey = stuff.boi;
+      })(require);
+    `);
+  });
+
+  it('transforms the simplified commonjs wrapper with weird variable names', () => {
+    expect(`
+      define((llamas, cows, bears) => {
+        var stuff = llamas('hi');
+        cows.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        ((llamas, cows, bears) => {
+          var stuff = llamas('hi');
+          cows.hey = stuff.boi;
+        })(require, exports, module)
+      `)
+    );
+    expect(`
+      define((llamas, cows) => {
+        var stuff = llamas('hi');
+        cows.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        ((llamas, cows) => {
+          var stuff = llamas('hi');
+          cows.hey = stuff.boi;
+        })(require, exports)
+      `)
+    );
+    expect(`
+      define((donkeys) => {
+        var stuff = donkeys('hi');
+        exports.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(`
+      module.exports = ((donkeys) => {
+        var stuff = donkeys('hi');
+        exports.hey = stuff.boi;
+      })(require);
+    `);
+  });
+
+  it('accounts for variable name conflicts when checking the result of `define`', () => {
+    expect(`
+      var amdDefineResult = 'for some reason I have this variable declared already';
+      define((require, exports, module) => {
+        var stuff = require('hi');
+        exports.hey = stuff.boi;
+      });
+    `).toBeTransformedTo(
+      `var amdDefineResult = 'for some reason I have this variable declared already';` +
+        checkAmdDefineResult(
+          `
+            ((require, exports, module) => {
+              var stuff = require('hi');
+              exports.hey = stuff.boi;
+            })(require, exports, module)
+          `,
+          `_${AMD_DEFINE_RESULT}`
+        )
+    );
+  });
+
+  it("lets you declare a dependency as `module` even though that's crazy", () => {
+    expect(`
+      define(['notmodule'], (module) => {
+        return {
+          notmodule: module.notmodule
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var module = require('notmodule');
+        return {
+          notmodule: module.notmodule
+        };
+      }();
+    `);
+  });
+
+  it("lets you declare a dependency as `exports` even though that's crazy", () => {
+    expect(`
+      define(['notexports'], (exports) => {
+        return {
+          notexports: exports.notexports
+        };
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var exports = require('notexports');
+        return {
+          notexports: exports.notexports
+        };
+      }();
+    `);
+  });
+});

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -5,18 +5,29 @@ const { AMD_DEFINE_RESULT } = require('../src/constants');
 describe('Plugin for define blocks', () => {
   it('transforms anonymous define blocks with one dependency', () => {
     expect(`
-      define(['stuff'], (donkeys) => {
+      define(['stuff'], donkeys => {
         return {
           llamas: donkeys.version
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var donkeys = require('stuff');
         return {
           llamas: donkeys.version
         };
-      }();
+      })();
+    `);
+  });
+
+  it('transforms anonymous define blocks with one dependency and implicit return value', () => {
+    expect(`
+      define(['stuff'], donkeys => ({ llamas: donkeys.version }))
+    `).toBeTransformedTo(`
+      module.exports = (() => {
+            var donkeys = require('stuff');
+            return { llamas: donkeys.version };
+      })();
     `);
   });
 
@@ -29,14 +40,26 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var donkeys = require('stuff');
         var aruba = require('here');
         return {
           llamas: donkeys.version,
           cows: aruba.hi
         };
-      }();
+      })();
+    `);
+  });
+
+  it('transforms anonymous define blocks with multiple dependencies and implicit return value', () => {
+    expect(`
+      define(['stuff', 'here'], (donkeys, aruba) => ({ llamas: donkeys.version, cows: aruba.hi }));
+    `).toBeTransformedTo(`
+      module.exports = (() => {
+            var donkeys = require('stuff');
+            var aruba = require('here');
+            return { llamas: donkeys.version, cows: aruba.hi };
+      })();
     `);
   });
 
@@ -48,13 +71,13 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var donkeys = require('stuff');
         require('here');
         return {
           llamas: donkeys.version
         };
-      }();
+      })();
     `);
   });
 
@@ -77,11 +100,11 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         return {
           llamas: 'donkeys'
         };
-      }();
+      })();
     `);
   });
 
@@ -95,12 +118,12 @@ describe('Plugin for define blocks', () => {
       });
     `).toBeTransformedTo(`
       var dependency = 'hey';
-      module.exports = function() {
+      module.exports = (() => {
         var here = require(dependency);
         return {
           llamas: here.hi
         };
-      }();
+      })();
     `);
   });
 
@@ -112,12 +135,12 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var here = require('hi');
         return {
           llamas: here.hi
         };
-      }();
+      })();
     `);
   });
 
@@ -129,11 +152,11 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         return {
           llamas: 'they are fluffy'
         };
-      }();
+      })();
     `);
   });
 
@@ -143,9 +166,9 @@ describe('Plugin for define blocks', () => {
         var x = require('x');
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var x = require('x');
-      }();
+      })();
     `);
   });
 
@@ -161,9 +184,9 @@ describe('Plugin for define blocks', () => {
       });
     `).toBeTransformedTo(
       checkAmdDefineResult(`
-        function() {
+        (() => {
           module.exports = { hey: 'boi' };
-        }()
+        })()
       `)
     );
   });
@@ -175,9 +198,9 @@ describe('Plugin for define blocks', () => {
       });
     `).toBeTransformedTo(
       checkAmdDefineResult(`
-        function() {
+        (() => {
           exports.hey = 'boi';
-        }()
+        })()
       `)
     );
   });
@@ -291,12 +314,12 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var module = require('notmodule');
         return {
           notmodule: module.notmodule
         };
-      }();
+      })();
     `);
   });
 
@@ -308,12 +331,12 @@ describe('Plugin for define blocks', () => {
         };
       });
     `).toBeTransformedTo(`
-      module.exports = function() {
+      module.exports = (() => {
         var exports = require('notexports');
         return {
           notexports: exports.notexports
         };
-      }();
+      })();
     `);
   });
 });

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -2,7 +2,7 @@
 
 const { AMD_DEFINE_RESULT } = require('../src/constants');
 
-describe('Plugin for define blocks', () => {
+describe('Plugin for define blocks with arrow function factories', () => {
   it('transforms anonymous define blocks with one dependency', () => {
     expect(`
       define(['stuff'], donkeys => {

--- a/tests/require-arrow.test.js
+++ b/tests/require-arrow.test.js
@@ -7,9 +7,20 @@ describe('Plugin for require blocks', () => {
         llama.doSomeStuff();
       });
     `).toBeTransformedTo(`
-      (function() {
+      (() => {
         var llama = require('llamas');
         llama.doSomeStuff();
+      })();
+    `);
+  });
+
+  it('transforms require blocks with one dependency and implicit return', () => {
+    expect(`
+      require(['llamas'], (llama) => llama.doSomeStuff());
+    `).toBeTransformedTo(`
+      (() => {
+            var llama = require('llamas');
+            return llama.doSomeStuff();
       })();
     `);
   });
@@ -21,11 +32,23 @@ describe('Plugin for require blocks', () => {
         frog.sayRibbit();
       });
     `).toBeTransformedTo(`
-      (function() {
+      (() => {
         var llama = require('llamas');
         var frog = require('frogs');
         llama.doSomeStuff();
         frog.sayRibbit();
+      })();
+    `);
+  });
+
+  it('transforms require blocks with multiple dependencies and implicit return', () => {
+    expect(`
+      require(['llamas', 'frogs'], (llama, frog) => llama.doSomeStuff(frogs));
+    `).toBeTransformedTo(`
+      (() => {
+            var llama = require('llamas');
+            var frog = require('frogs');
+            return llama.doSomeStuff(frogs);
       })();
     `);
   });
@@ -36,7 +59,7 @@ describe('Plugin for require blocks', () => {
         llama.doSomeStuff();
       });
     `).toBeTransformedTo(`
-      (function() {
+      (() => {
         var llama = require('llamas');
         require('frogs');
         llama.doSomeStuff();
@@ -51,7 +74,7 @@ describe('Plugin for require blocks', () => {
         require(['yep', 'that', 'me']);
       });
     `).toBeTransformedTo(`
-      (function() {
+      (() => {
         var here = require('here');
         require('is');
         require('i');
@@ -72,12 +95,12 @@ describe('Plugin for require blocks', () => {
         });
       });
     `).toBeTransformedTo(`
-      (function() {
+      (() => {
         var here = require('here');
         require('is');
         require('i');
         here.doStuff();
-        (function() {
+        (() => {
           var yep = require('yep');
           require('that');
           require('me');
@@ -96,12 +119,12 @@ describe('Plugin for require blocks', () => {
         });
       });
     `).toBeTransformedTo(`
-      module.exports = (function() {
+      module.exports = (() => {
         var here = require('here');
         require('is');
         require('i');
         here.doStuff();
-        (function() {
+        (() => {
           var yep = require('yep');
           require('that');
           require('me');

--- a/tests/require-arrow.test.js
+++ b/tests/require-arrow.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+describe('Plugin for require blocks', () => {
+  it('transforms require blocks with one dependency', () => {
+    expect(`
+      require(['llamas'], (llama) => {
+        llama.doSomeStuff();
+      });
+    `).toBeTransformedTo(`
+      (function() {
+        var llama = require('llamas');
+        llama.doSomeStuff();
+      })();
+    `);
+  });
+
+  it('transforms require blocks with multiple dependencies', () => {
+    expect(`
+      require(['llamas', 'frogs'], (llama, frog) => {
+        llama.doSomeStuff();
+        frog.sayRibbit();
+      });
+    `).toBeTransformedTo(`
+      (function() {
+        var llama = require('llamas');
+        var frog = require('frogs');
+        llama.doSomeStuff();
+        frog.sayRibbit();
+      })();
+    `);
+  });
+
+  it('transforms require blocks with unused dependencies', () => {
+    expect(`
+      require(['llamas', 'frogs'], (llama) => {
+        llama.doSomeStuff();
+      });
+    `).toBeTransformedTo(`
+      (function() {
+        var llama = require('llamas');
+        require('frogs');
+        llama.doSomeStuff();
+      })();
+    `);
+  });
+
+  it('transforms nested require blocks that have no factory function', () => {
+    expect(`
+      require(['here', 'is', 'i'], (here) => {
+        here.doStuff();
+        require(['yep', 'that', 'me']);
+      });
+    `).toBeTransformedTo(`
+      (function() {
+        var here = require('here');
+        require('is');
+        require('i');
+        here.doStuff();
+        require('yep');
+        require('that');
+        require('me');
+      })();
+    `);
+  });
+
+  it('transforms nested require blocks that have a factory function', () => {
+    expect(`
+      require(['here', 'is', 'i'], (here) => {
+        here.doStuff();
+        require(['yep', 'that', 'me'], (yep) => {
+          yep.doStuff();
+        });
+      });
+    `).toBeTransformedTo(`
+      (function() {
+        var here = require('here');
+        require('is');
+        require('i');
+        here.doStuff();
+        (function() {
+          var yep = require('yep');
+          require('that');
+          require('me');
+          yep.doStuff();
+        })();
+      })();
+    `);
+  });
+
+  it('transforms a require block that is within a define block', () => {
+    expect(`
+      define(['here', 'is', 'i'], (here) => {
+        here.doStuff();
+        require(['yep', 'that', 'me'], (yep) => {
+          yep.doStuff();
+        });
+      });
+    `).toBeTransformedTo(`
+      module.exports = (function() {
+        var here = require('here');
+        require('is');
+        require('i');
+        here.doStuff();
+        (function() {
+          var yep = require('yep');
+          require('that');
+          require('me');
+          yep.doStuff();
+        })();
+      })();
+    `);
+  });
+});

--- a/tests/require-arrow.test.js
+++ b/tests/require-arrow.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Plugin for require blocks', () => {
+describe('Plugin for require blocks with arrow function callbacks', () => {
   it('transforms require blocks with one dependency', () => {
     expect(`
       require(['llamas'], (llama) => {
@@ -43,12 +43,12 @@ describe('Plugin for require blocks', () => {
 
   it('transforms require blocks with multiple dependencies and implicit return', () => {
     expect(`
-      require(['llamas', 'frogs'], (llama, frog) => llama.doSomeStuff(frogs));
+      require(['llamas', 'frogs'], (llama, frog) => llama.doSomeStuff(frog));
     `).toBeTransformedTo(`
       (() => {
             var llama = require('llamas');
             var frog = require('frogs');
-            return llama.doSomeStuff(frogs);
+            return llama.doSomeStuff(frog);
       })();
     `);
   });


### PR DESCRIPTION
Fixes https://github.com/msrose/babel-plugin-transform-amd-to-commonjs/issues/36