### PR TITLE
Add option for transforming non top-level define

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ Output:
 })();
 ```
 
+## Options 
+
+Specify options in your .babelrc:
+
+```
+{
+  "plugins": [
+    ["transform-amd-to-commonjs", { "restrictToTopLevelDefine": true }]
+  ]
+}
+```
+
+- `restrictToTopLevelDefine`: (default: `true`) When `true`, only transform `define` calls that appear at the top-level of a program. Set to `false` to transform _all_ calls to `define`.
+
 ## Details
 
 ### Supported Versions
@@ -96,7 +110,7 @@ npm install --save-dev babel-plugin-transform-amd-to-commonjs@0.2.2
 
 AMD is interpreted as described by the [AMD specification](https://github.com/amdjs/amdjs-api/blob/master/AMD.md).
 
-- Only _top-level_ calls to a `define` function will be transformed.
+- By default, only _top-level_ calls to a `define` function will be transformed. Use the `restrictToTopLevelDefine` option to transform calls that are not at the top-level.
 - _All_ calls to `require` where it is given an array of dependencies as its first argument will be transformed.
 - Explicitly requiring `require`, `module`, and `exports` in an AMD module will not generate a call to require, but instead defer to the global require, module, and exports assumed to be in the CommonJS environment you are transforming to.
   - The same is true for the [simplified CommonJS wrapper](http://requirejs.org/docs/api.html#cjsmodule).

--- a/src/index.js
+++ b/src/index.js
@@ -27,15 +27,17 @@ module.exports = ({ types: t }) => {
     return array1.map((element, index) => [element, array2[index]]);
   };
 
-  const ExpressionStatement = path => {
+  const ExpressionStatement = (path, { opts }) => {
     const { node, parent } = path;
 
     if (!t.isCallExpression(node.expression)) return;
 
+    const options = Object.assign({ restrictToTopLevelDefine: true }, opts);
+
     const { name } = node.expression.callee;
     const isDefineCall = name === DEFINE;
 
-    if (isDefineCall && !t.isProgram(parent)) return;
+    if (isDefineCall && options.restrictToTopLevelDefine && !t.isProgram(parent)) return;
 
     const argumentDecoder = argumentDecoders[name];
 

--- a/tests/custom-matchers.js
+++ b/tests/custom-matchers.js
@@ -3,8 +3,8 @@
 const babel = require('babel-core');
 const diff = require('jest-diff');
 
-const transformAmdToCommonJS = code => {
-  return babel.transform(code, { plugins: ['./src/index'], babelrc: false }).code;
+const transformAmdToCommonJS = (code, options = {}) => {
+  return babel.transform(code, { plugins: [['./src/index', options]], babelrc: false }).code;
 };
 
 const transformTrivial = code => {
@@ -20,7 +20,14 @@ const removeBlankLines = string => {
 
 const customMatchers = {
   toBeTransformedTo(actual, expected) {
-    const transformed = removeBlankLines(transformAmdToCommonJS(actual));
+    let options = {};
+
+    if (typeof actual !== 'string') {
+      options = actual.options;
+      actual = actual.program;
+    }
+
+    const transformed = removeBlankLines(transformAmdToCommonJS(actual, options));
     actual = removeBlankLines(transformTrivial(actual));
     expected = removeBlankLines(transformTrivial(expected));
 

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -81,7 +81,7 @@ describe('Plugin for define blocks with arrow function factories', () => {
     `);
   });
 
-  it('only transforms define blocks at the top level', () => {
+  it('only transforms define blocks at the top level by default', () => {
     const program = `
       if(someDumbCondition) {
         define(['stuff'], (stuff) => {
@@ -90,6 +90,26 @@ describe('Plugin for define blocks with arrow function factories', () => {
       }
     `;
     expect(program).toBeTransformedTo(program);
+  });
+
+  it('transforms non-top-level define blocks when the option is specified', () => {
+    expect({
+      options: { restrictToTopLevelDefine: false },
+      program: `
+        if(someDumbCondition) {
+          define(['stuff'], stuff => {
+            return { hi: 'world' };
+          });
+        }
+      `
+    }).toBeTransformedTo(`
+      if(someDumbCondition) {
+        module.exports = (() => {
+          var stuff = require('stuff');
+          return { hi: 'world' };
+        })();
+      }
+    `);
   });
 
   it('transforms anonymous define blocks with no dependency list', () => {

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -58,7 +58,7 @@ describe('Plugin for define blocks', () => {
     `);
   });
 
-  it('only transforms define blocks at the top level', () => {
+  it('only transforms define blocks at the top level by default', () => {
     const program = `
       if(someDumbCondition) {
         define(['stuff'], function(stuff) {
@@ -67,6 +67,26 @@ describe('Plugin for define blocks', () => {
       }
     `;
     expect(program).toBeTransformedTo(program);
+  });
+
+  it('transforms non-top-level define blocks when the option is specified', () => {
+    expect({
+      options: { restrictToTopLevelDefine: false },
+      program: `
+        if(someDumbCondition) {
+          define(['stuff'], function(stuff) {
+            return { hi: 'world' };
+          });
+        }
+      `
+    }).toBeTransformedTo(`
+      if(someDumbCondition) {
+        module.exports = (function() {
+          var stuff = require('stuff');
+          return { hi: 'world' };
+        })();
+      }
+    `);
   });
 
   it('transforms anonymous define blocks with no dependency list', () => {


### PR DESCRIPTION
See discussion in #38 for more details. The ability to transform non-top-level define calls is a prerequisite for supporting more complex usages of AMD. 

Default set to true for backwards compatibility, but it might make sense to make the default false in the next major version. 

The behaviour for nested defines is undefined and not supported.