### PR TITLE
Check non-function literals for functions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -5,5 +5,6 @@ module.exports = {
   MODULE: 'module',
   EXPORTS: 'exports',
   DEFINE: 'define',
-  AMD_DEFINE_RESULT: 'amdDefineResult'
+  AMD_DEFINE_RESULT: 'amdDefineResult',
+  MAYBE_FUNCTION: 'maybeFunction'
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -114,6 +114,35 @@ module.exports = ({ types: t }) => {
     );
   };
 
+  const createFunctionCheck = (factory, identifier, requireExpressions) => {
+    return [
+      t.variableDeclaration('var', [t.variableDeclarator(identifier, factory)]),
+      createModuleExportsAssignmentExpression(
+        t.conditionalExpression(
+          t.binaryExpression(
+            '===',
+            t.unaryExpression('typeof', identifier),
+            t.stringLiteral('function')
+          ),
+          t.callExpression(
+            identifier,
+            requireExpressions.length > 0
+              ? requireExpressions.map(e => e.expression)
+              : [REQUIRE, EXPORTS, MODULE].map(a => t.identifier(a))
+          ),
+          t.callExpression(
+            t.functionExpression(
+              null,
+              [],
+              t.blockStatement(requireExpressions.concat(t.returnStatement(identifier)))
+            ),
+            []
+          )
+        )
+      )
+    ];
+  };
+
   return {
     decodeDefineArguments,
     decodeRequireArguments,
@@ -124,6 +153,7 @@ module.exports = ({ types: t }) => {
     isModuleOrExportsInjected,
     getUniqueIdentifier,
     isFunctionExpression,
-    createFactoryReplacementExpression
+    createFactoryReplacementExpression,
+    createFunctionCheck
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 'use strict';
 
-const { REQUIRE, MODULE, EXPORTS, DEFINE, AMD_DEFINE_RESULT } = require('./constants');
+const {
+  REQUIRE,
+  MODULE,
+  EXPORTS,
+  DEFINE,
+  AMD_DEFINE_RESULT,
+  MAYBE_FUNCTION
+} = require('./constants');
 const createHelpers = require('./helpers');
 
 module.exports = ({ types: t }) => {
@@ -14,7 +21,8 @@ module.exports = ({ types: t }) => {
     createModuleExportsResultCheck,
     getUniqueIdentifier,
     isFunctionExpression,
-    createFactoryReplacementExpression
+    createFactoryReplacementExpression,
+    createFunctionCheck
   } = createHelpers({ types: t });
 
   const argumentDecoders = {
@@ -94,9 +102,12 @@ module.exports = ({ types: t }) => {
         path.replaceWith(factoryReplacement);
       }
     } else if (factory && isDefineCall) {
-      const exportExpression = createModuleExportsAssignmentExpression(factory);
-      const nodes = requireExpressions.concat(exportExpression);
-      path.replaceWithMultiple(nodes);
+      const functionCheckNodes = createFunctionCheck(
+        factory,
+        getUniqueIdentifier(path.scope, MAYBE_FUNCTION),
+        requireExpressions
+      );
+      path.replaceWithMultiple(functionCheckNodes);
     } else {
       path.replaceWithMultiple(requireExpressions);
     }

--- a/tests/custom-matchers.js
+++ b/tests/custom-matchers.js
@@ -18,13 +18,6 @@ const removeBlankLines = string => {
     .join('\n');
 };
 
-const trimLines = string => {
-  return string
-    .split('\n')
-    .map(line => line.trim())
-    .join('\n');
-};
-
 const customMatchers = {
   toBeTransformedTo(actual, expected) {
     let options = {};
@@ -39,7 +32,7 @@ const customMatchers = {
     const transformed = removeBlankLines(transformAmdToCommonJS(actual, options));
 
     const result = {
-      pass: trimLines(transformed) === trimLines(expected)
+      pass: transformed === expected
     };
 
     if (result.pass) {

--- a/tests/custom-matchers.js
+++ b/tests/custom-matchers.js
@@ -18,6 +18,13 @@ const removeBlankLines = string => {
     .join('\n');
 };
 
+const trimLines = string => {
+  return string
+    .split('\n')
+    .map(line => line.trim())
+    .join('\n');
+};
+
 const customMatchers = {
   toBeTransformedTo(actual, expected) {
     let options = {};
@@ -27,12 +34,12 @@ const customMatchers = {
       actual = actual.program;
     }
 
-    const transformed = removeBlankLines(transformAmdToCommonJS(actual, options));
     actual = removeBlankLines(transformTrivial(actual));
     expected = removeBlankLines(transformTrivial(expected));
+    const transformed = removeBlankLines(transformAmdToCommonJS(actual, options));
 
     const result = {
-      pass: transformed === expected
+      pass: trimLines(transformed) === trimLines(expected)
     };
 
     if (result.pass) {

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { AMD_DEFINE_RESULT, MAYBE_FUNCTION, REQUIRE, EXPORTS, MODULE } = require('../src/constants');
+const { AMD_DEFINE_RESULT, MAYBE_FUNCTION } = require('../src/constants');
+const { checkAmdDefineResult, checkMaybeFunction } = require('./test-helpers');
 
 describe('Plugin for define blocks', () => {
   it('transforms anonymous define blocks with one dependency', () => {
@@ -181,11 +182,6 @@ describe('Plugin for define blocks', () => {
       }();
     `);
   });
-
-  const checkAmdDefineResult = (value, identifier = AMD_DEFINE_RESULT) => `
-    var ${identifier} = ${value};
-    typeof ${identifier} !== "undefined" && (module.exports = ${identifier});
-  `;
 
   it('handles injection of a dependency named `module`', () => {
     expect(`
@@ -379,30 +375,6 @@ describe('Plugin for define blocks', () => {
       }();
     `);
   });
-
-  const checkMaybeFunction = (factory, dependencies, identifier = MAYBE_FUNCTION) => {
-    const amdKeywords = [REQUIRE, EXPORTS, MODULE];
-    const requiredDependencies = (dependencies || []).map(d => {
-      if (amdKeywords.includes(d)) {
-        return d;
-      }
-      return `require('${d}')`;
-    });
-    const injectedDependencies = dependencies
-      ? requiredDependencies.join(',')
-      : amdKeywords.join(',');
-    return `
-      var ${identifier} = ${factory};
-      module.exports = (
-        typeof ${identifier} === "function"
-          ? ${identifier}(${injectedDependencies})
-          : (function() {
-            ${requiredDependencies.filter(d => !amdKeywords.includes(d)).join(';\n')}
-            return ${identifier};
-          })()
-      );
-    `;
-  };
 
   it('transforms non-function modules exporting objects with no dependencies', () => {
     expect(`

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -381,22 +381,23 @@ describe('Plugin for define blocks', () => {
   });
 
   const checkMaybeFunction = (factory, dependencies) => {
+    const amdKeywords = [REQUIRE, EXPORTS, MODULE];
     const requiredDependencies = (dependencies || []).map(d => {
-      if ([REQUIRE, EXPORTS, MODULE].includes(d)) {
+      if (amdKeywords.includes(d)) {
         return d;
       }
       return `require('${d}')`;
     });
     const injectedDependencies = dependencies
       ? requiredDependencies.join(',')
-      : `${REQUIRE}, ${EXPORTS}, ${MODULE}`;
+      : amdKeywords.join(',');
     return `
       var ${MAYBE_FUNCTION} = ${factory};
       module.exports = (
-        typeof ${MAYBE_FUNCTION} === 'function'
+        typeof ${MAYBE_FUNCTION} === "function"
           ? ${MAYBE_FUNCTION}(${injectedDependencies})
           : (function() {
-            ${requiredDependencies.join(';\n')}
+            ${requiredDependencies.filter(d => !amdKeywords.includes(d)).join(';\n')}
             return ${MAYBE_FUNCTION};
           })()
       );
@@ -459,17 +460,17 @@ describe('Plugin for define blocks', () => {
 
   it('transforms non-function modules requiring `require` for some reason', () => {
     expect(`
-      define(['require'], { some: 'stuff' });
+      define(['sup', 'require'], { some: 'stuff' });
     `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ some: 'stuff' }", ['require'])}
+      ${checkMaybeFunction("{ some: 'stuff' }", ['sup', 'require'])}
     `);
   });
 
   it('transforms non-function modules requiring `exports` for some reason', () => {
     expect(`
-      define(['exports'], { some: 'stuff' });
+      define(['exports', 'dawg'], { some: 'stuff' });
     `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ some: 'stuff' }", ['exports'])}
+      ${checkMaybeFunction("{ some: 'stuff' }", ['exports', 'dawg'])}
     `);
   });
 

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -407,33 +407,27 @@ describe('Plugin for define blocks', () => {
   it('transforms non-function modules exporting objects with no dependencies', () => {
     expect(`
       define({ thismodule: 'is an object' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ thismodule: 'is an object' }")}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ thismodule: 'is an object' }"));
   });
 
   it('transforms non-function modules exporting objects with dependencies', () => {
     expect(`
       define(['side-effect'], { thismodule: 'is an object' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ thismodule: 'is an object' }", ['side-effect'])}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ thismodule: 'is an object' }", ['side-effect']));
   });
 
   it('transforms non-function modules exporting arrays with no dependencies', () => {
     expect(`
       define(['this', 'module', 'is', 'an', 'array']);
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("['this', 'module', 'is', 'an', 'array']")}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("['this', 'module', 'is', 'an', 'array']"));
   });
 
   it('transforms non-function modules exporting arrays with dependencies', () => {
     expect(`
       define(['side-effect'], ['this', 'module', 'is', 'an', 'array']);
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("['this', 'module', 'is', 'an', 'array']", ['side-effect'])}
-    `);
+    `).toBeTransformedTo(
+      checkMaybeFunction("['this', 'module', 'is', 'an', 'array']", ['side-effect'])
+    );
   });
 
   it('transforms non-function modules exporting primitives with no dependencies', () => {
@@ -441,9 +435,7 @@ describe('Plugin for define blocks', () => {
     primitives.forEach(primitive => {
       expect(`
         define(${primitive});
-      `).toBeTransformedTo(`
-        ${checkMaybeFunction(primitive)}
-      `);
+      `).toBeTransformedTo(checkMaybeFunction(primitive));
     });
   });
 
@@ -452,60 +444,44 @@ describe('Plugin for define blocks', () => {
     primitives.forEach(primitive => {
       expect(`
         define(['side-effect'], ${primitive});
-      `).toBeTransformedTo(`
-        ${checkMaybeFunction(primitive, ['side-effect'])}
-      `);
+      `).toBeTransformedTo(checkMaybeFunction(primitive, ['side-effect']));
     });
   });
 
   it('transforms non-function modules requiring `require` for some reason', () => {
     expect(`
       define(['sup', 'require'], { some: 'stuff' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ some: 'stuff' }", ['sup', 'require'])}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['sup', 'require']));
   });
 
   it('transforms non-function modules requiring `exports` for some reason', () => {
     expect(`
       define(['exports', 'dawg'], { some: 'stuff' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ some: 'stuff' }", ['exports', 'dawg'])}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['exports', 'dawg']));
   });
 
   it('transforms non-function modules requiring `module` for some reason', () => {
     expect(`
       define(['module'], { some: 'stuff' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ some: 'stuff' }", ['module'])}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['module']));
   });
 
   it('transforms named non-function modules with no dependencies', () => {
     expect(`
       define('auselessname', { thismodule: 'is an object' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ thismodule: 'is an object' }")}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ thismodule: 'is an object' }"));
     expect(`
       define('auselessname', ['an', 'array', 'factory']);
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("['an', 'array', 'factory']")}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("['an', 'array', 'factory']"));
   });
 
   it('transforms named non-function modules with dependencies', () => {
     expect(`
       define('auselessname', ['side-effect'], { thismodule: 'is an object' });
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("{ thismodule: 'is an object' }", ['side-effect'])}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("{ thismodule: 'is an object' }", ['side-effect']));
     expect(`
       define('auselessname', ['side-effect'], ['an', 'array', 'factory']);
-    `).toBeTransformedTo(`
-      ${checkMaybeFunction("['an', 'array', 'factory']", ['side-effect'])}
-    `);
+    `).toBeTransformedTo(checkMaybeFunction("['an', 'array', 'factory']", ['side-effect']));
   });
 
   it('checks non function-literal factories to see if they are actually functions', () => {

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { REQUIRE, EXPORTS, MODULE, AMD_DEFINE_RESULT, MAYBE_FUNCTION } = require('../src/constants');
+
+const checkAmdDefineResult = (value, identifier = AMD_DEFINE_RESULT) => `
+  var ${identifier} = ${value};
+  typeof ${identifier} !== "undefined" && (module.exports = ${identifier});
+`;
+
+const checkMaybeFunction = (factory, dependencies, identifier = MAYBE_FUNCTION) => {
+  const amdKeywords = [REQUIRE, EXPORTS, MODULE];
+  const requiredDependencies = (dependencies || []).map(d => {
+    if (amdKeywords.includes(d)) {
+      return d;
+    }
+    return `require('${d}')`;
+  });
+  const injectedDependencies = dependencies
+    ? requiredDependencies.join(',')
+    : amdKeywords.join(',');
+  return `
+      var ${identifier} = ${factory};
+      module.exports = (
+        typeof ${identifier} === "function"
+          ? ${identifier}(${injectedDependencies})
+          : (function() {
+            ${requiredDependencies.filter(d => !amdKeywords.includes(d)).join(';\n')}
+            return ${identifier};
+          })()
+      );
+    `;
+};
+
+module.exports = {
+  checkAmdDefineResult,
+  checkMaybeFunction
+};


### PR DESCRIPTION
Addresses #39 

~TODO~

- [x] ~write code to fix breaking tests (injection of require, module, and exports when explicitly required)~
- [x] ~fix quote transformation in some tests (why is this even happening?)~
    - Seems like babel upgrade fixed this

Not covered: combinations of "module/exports result check" and "function check". For example,
```js
var factory = function(module) {
    module.exports = 'sup'
}
define(['module'], factory)
```
should be transformed to something like
```js
var factory = function(module) {
    module.exports = 'sup'
}
if(typeof factory === "function") {
    var amdDefineResult = factory(module)
    typeof amdDefineResult !== "undefined" && (module.exports = amdDefineResult)
} else {
    module.exports = function() {
        return factory
    }()
}
```
so that 'sup' is correctly exported, but the amdDefineResult check is missing, so we get
```js
var factory = function(module) {
    module.exports = 'sup'
}
module.exports = typeof factory === "function" ? factory(module) : function() {
    return factory
}()
```
instead and `undefined` gets exported incorrectly.