### PR TITLE
Extending support for injecting require, module & exports as dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ It is strongly advised to simply use return statements to define your AMD module
 That being said, the plugin takes into account the cases where you may have injected them as dependencies.
 Beware of the following gotchas when using this pattern:
 
-- If you're injecting `module`, `exports`, and/or `require` as dependencies, they must be injected as string literals,
-otherwise you'll end up with things like `require('module')`.
 - Returning any value other than `undefined` from a factory function will override anything you assign to `module` or `exports`.
   This behaviour is in accordance with the AMD specification.
   Unless you're doing something really weird in your modules, you don't have to worry about this case, but the plugin handles it by performing a check as needed on the return value of the factory function.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ It is strongly advised to simply use return statements to define your AMD module
 That being said, the plugin takes into account the cases where you may have injected them as dependencies.
 Beware of the following gotchas when using this pattern:
 
+- If you're injecting `module`, `exports`, and/or `require` as dependencies, they must be injected as string literals,
 - Returning any value other than `undefined` from a factory function will override anything you assign to `module` or `exports`.
   This behaviour is in accordance with the AMD specification.
   Unless you're doing something really weird in your modules, you don't have to worry about this case, but the plugin handles it by performing a check as needed on the return value of the factory function.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ That being said, the plugin takes into account the cases where you may have inje
 Beware of the following gotchas when using this pattern:
 
 - If you're injecting `module`, `exports`, and/or `require` as dependencies, they must be injected as string literals,
+otherwise you'll end up with things like `require('module')`.
 - Returning any value other than `undefined` from a factory function will override anything you assign to `module` or `exports`.
   This behaviour is in accordance with the AMD specification.
   Unless you're doing something really weird in your modules, you don't have to worry about this case, but the plugin handles it by performing a check as needed on the return value of the factory function.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -50,11 +50,10 @@ module.exports = ({ types: t }) => {
     ];
   };
 
-  const createRequireExpression = (dependencyNode, variableName) => {
+  const createDependencyInjectionExpression = (dependencyNode, variableName) => {
     if (
-      dependencyNode.value === MODULE ||
-      dependencyNode.value === EXPORTS ||
-      dependencyNode.value === REQUIRE
+      t.isStringLiteral(dependencyNode) &&
+      [MODULE, EXPORTS, REQUIRE].includes(dependencyNode.value)
     ) {
       // In case of the AMD keywords, only create an expression if the variable name
       // does not match the keyword. This to prevent 'require = require' statements.
@@ -134,7 +133,7 @@ module.exports = ({ types: t }) => {
     decodeRequireArguments,
     createModuleExportsAssignmentExpression,
     createModuleExportsResultCheck,
-    createRequireExpression,
+    createDependencyInjectionExpression,
     isSimplifiedCommonJSWrapper,
     isModuleOrExportsInjected,
     getUniqueIdentifier,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -51,6 +51,21 @@ module.exports = ({ types: t }) => {
   };
 
   const createRequireExpression = (dependencyNode, variableName) => {
+    if (
+      dependencyNode.value === MODULE ||
+      dependencyNode.value === EXPORTS ||
+      dependencyNode.value === REQUIRE
+    ) {
+      // In case of the AMD keywords, only create an expression if the variable name
+      // does not match the keyword. This to prevent 'require = require' statements.
+      if (variableName && variableName.name !== dependencyNode.value) {
+        return t.variableDeclaration('var', [
+          t.variableDeclarator(variableName, t.identifier(dependencyNode.value))
+        ]);
+      }
+      return undefined;
+    }
+
     const requireCall = t.callExpression(t.identifier(REQUIRE), [dependencyNode]);
     if (variableName) {
       return t.variableDeclaration('var', [t.variableDeclarator(variableName, requireCall)]);

--- a/src/index.js
+++ b/src/index.js
@@ -59,11 +59,11 @@ module.exports = ({ types: t }) => {
       );
 
       const explicitRequires = dependencyParameterPairs
-        .filter(([dependency]) => {
-          return !t.isStringLiteral(dependency) || !keywords.includes(dependency.value);
-        })
         .map(([dependency, paramName]) => {
           return createRequireExpression(dependency, paramName);
+        })
+        .filter(requireExpression => {
+          return requireExpression; // Remove 'undefined' expressions
         });
 
       requireExpressions.push(...explicitRequires);

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ module.exports = ({ types: t }) => {
     decodeRequireArguments,
     isModuleOrExportsInjected,
     isSimplifiedCommonJSWrapper,
-    createRequireExpression,
+    createDependencyInjectionExpression,
     createModuleExportsAssignmentExpression,
     createModuleExportsResultCheck,
     getUniqueIdentifier,
@@ -60,10 +60,10 @@ module.exports = ({ types: t }) => {
 
       const explicitRequires = dependencyParameterPairs
         .map(([dependency, paramName]) => {
-          return createRequireExpression(dependency, paramName);
+          return createDependencyInjectionExpression(dependency, paramName);
         })
         .filter(requireExpression => {
-          return requireExpression; // Remove 'undefined' expressions
+          return requireExpression !== undefined;
         });
 
       requireExpressions.push(...explicitRequires);

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -192,6 +192,19 @@ describe('Plugin for define blocks with arrow function factories', () => {
     `);
   });
 
+  it('does not require a dependency named `require` (ugly)', () => {
+    expect(`
+      define(['require'], (abc) => {
+        var x = abc('x');
+      });
+    `).toBeTransformedTo(`
+      module.exports = (() => {
+        var abc = require;
+        var x = abc('x');
+      })();
+    `);
+  });
+
   const checkAmdDefineResult = (value, identifier = AMD_DEFINE_RESULT) => `
     var ${identifier} = ${value};
     typeof ${identifier} !== 'undefined' && (module.exports = ${identifier});
@@ -211,6 +224,21 @@ describe('Plugin for define blocks with arrow function factories', () => {
     );
   });
 
+  it('handles injection of a dependency named `module` (ugly)', () => {
+    expect(`
+      define(['module'], (abc) => {
+        abc.exports = { hey: 'boi' };
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        (() => {
+          var abc = module;
+          abc.exports = { hey: 'boi' };
+        })()
+      `)
+    );
+  });
+
   it('handles injection of dependency named `exports`', () => {
     expect(`
       define(['exports'], (exports) => {
@@ -220,6 +248,21 @@ describe('Plugin for define blocks with arrow function factories', () => {
       checkAmdDefineResult(`
         (() => {
           exports.hey = 'boi';
+        })()
+      `)
+    );
+  });
+
+  it('handles injection of dependency named `exports` (ugly)', () => {
+    expect(`
+      define(['exports'], (abc) => {
+        abc.hey = 'boi';
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        (() => {
+          var abc = exports;
+          abc.hey = 'boi';
         })()
       `)
     );

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -192,7 +192,7 @@ describe('Plugin for define blocks with arrow function factories', () => {
     `);
   });
 
-  it('does not require a dependency named `require` (ugly)', () => {
+  it('does not require a dependency named `require` which has been renamed', () => {
     expect(`
       define(['require'], (abc) => {
         var x = abc('x');
@@ -224,7 +224,7 @@ describe('Plugin for define blocks with arrow function factories', () => {
     );
   });
 
-  it('handles injection of a dependency named `module` (ugly)', () => {
+  it('handles injection of a dependency named `module` which has been renamed', () => {
     expect(`
       define(['module'], (abc) => {
         abc.exports = { hey: 'boi' };
@@ -253,7 +253,7 @@ describe('Plugin for define blocks with arrow function factories', () => {
     );
   });
 
-  it('handles injection of dependency named `exports` (ugly)', () => {
+  it('handles injection of dependency named `exports` which has been renamed', () => {
     expect(`
       define(['exports'], (abc) => {
         abc.hey = 'boi';

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -169,7 +169,7 @@ describe('Plugin for define blocks', () => {
     `);
   });
 
-  it('does not require a dependency named `require` (ugly)', () => {
+  it('does not require a dependency named `require` which has been renamed', () => {
     expect(`
       define(['require'], function(abc) {
         var x = abc('x');
@@ -201,7 +201,7 @@ describe('Plugin for define blocks', () => {
     );
   });
 
-  it('handles injection of dependency named `module` (ugly)', () => {
+  it('handles injection of dependency named `module` which has been renamed', () => {
     expect(`
       define(['module'], function(abc) {
         abc.exports.hey = 'boi';
@@ -230,7 +230,7 @@ describe('Plugin for define blocks', () => {
     );
   });
 
-  it('handles injection of dependency named `exports` (ugly)', () => {
+  it('handles injection of dependency named `exports` which has been renamed', () => {
     expect(`
       define(['exports'], function(abc) {
         abc.hey = 'boi';

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -169,6 +169,19 @@ describe('Plugin for define blocks', () => {
     `);
   });
 
+  it('does not require a dependency named `require` (ugly)', () => {
+    expect(`
+      define(['require'], function(abc) {
+        var x = abc('x');
+      });
+    `).toBeTransformedTo(`
+      module.exports = function() {
+        var abc = require;
+        var x = abc('x');
+      }();
+    `);
+  });
+
   const checkAmdDefineResult = (value, identifier = AMD_DEFINE_RESULT) => `
     var ${identifier} = ${value};
     typeof ${identifier} !== 'undefined' && (module.exports = ${identifier});
@@ -188,6 +201,21 @@ describe('Plugin for define blocks', () => {
     );
   });
 
+  it('handles injection of dependency named `module` (ugly)', () => {
+    expect(`
+      define(['module'], function(abc) {
+        abc.exports.hey = 'boi';
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        function() {
+          var abc = module;
+          abc.exports.hey = 'boi';
+        }()
+      `)
+    );
+  });
+
   it('handles injection of dependency named `exports`', () => {
     expect(`
       define(['exports'], function(exports) {
@@ -197,6 +225,21 @@ describe('Plugin for define blocks', () => {
       checkAmdDefineResult(`
         function() {
           exports.hey = 'boi';
+        }()
+      `)
+    );
+  });
+
+  it('handles injection of dependency named `exports` (ugly)', () => {
+    expect(`
+      define(['exports'], function(abc) {
+        abc.hey = 'boi';
+      });
+    `).toBeTransformedTo(
+      checkAmdDefineResult(`
+        function() {
+          var abc = exports;
+          abc.hey = 'boi';
         }()
       `)
     );


### PR DESCRIPTION
One of the third party libraries (we are using) is 'uglified' and is injecting 'exports' as variable 'a'. Since 'exports' dependencies are skipped, variable 'a' is not defined which makes the library faulty. This PR should resolve this issue.