### PR TITLE
Perform certain build tasks only on latest Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: node_js
 node_js:
-  - "8"
   - "6"
+  - "8"
   - "10"
 before_install:
   - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
+matrix:
+  include:
+    - node_js: "10"
+      env: HOUSEKEEP=1
 script:
-  - npm run lint
+  - [[ -n $HOUSEKEEP ]] && npm run lint
   - npm test -- --coverage
-  - npm run build
-after_script: greenkeeper-lockfile-upload
+  - [[ -n $HOUSEKEEP ]] && npm run build
+after_script: [[ -n $HOUSEKEEP ]] && greenkeeper-lockfile-upload
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - [[ -n $HOUSEKEEP ]] && bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,24 @@ node_js:
   - "6"
   - "8"
   - "10"
+env:
+  - HOUSEKEEP=0
+  - HOUSEKEEP=1
 before_install:
   - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 matrix:
-  include:
-    - node_js: "10"
+  exclude:
+    - node_js: "6"
       env: HOUSEKEEP=1
+    - node_js: "8"
+      env: HOUSEKEEP=1
+    - node_js: "10"
+      env: HOUSEKEEP=0
 script:
-  - "[[ -n $HOUSEKEEP ]] && npm run lint"
-  - npm test -- --coverage
-  - "[[ -n $HOUSEKEEP ]] && npm run build"
-after_script: "[[ -n $HOUSEKEEP ]] && greenkeeper-lockfile-upload"
+  - "if [ -n $HOUSEKEEP ]; then npm run lint; fi"
+  - "if [ -n $HOUSEKEEP ]; then npm test -- --coverage; else npm test; fi"
+  - "if [ -n $HOUSEKEEP ]; then npm run build; fi"
+after_script: "if [ -n $HOUSEKEEP ]; then greenkeeper-lockfile-upload; fi"
 after_success:
-  - "[[ -n $HOUSEKEEP ]] && bash <(curl -s https://codecov.io/bash)"
+  - "if [ -n $HOUSEKEEP ]; then bash <(curl -s https://codecov.io/bash); fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - node_js: "10"
       env: HOUSEKEEP=1
 script:
-  - [[ -n $HOUSEKEEP ]] && npm run lint
+  - "[[ -n $HOUSEKEEP ]] && npm run lint"
   - npm test -- --coverage
-  - [[ -n $HOUSEKEEP ]] && npm run build
-after_script: [[ -n $HOUSEKEEP ]] && greenkeeper-lockfile-upload
+  - "[[ -n $HOUSEKEEP ]] && npm run build"
+after_script: "[[ -n $HOUSEKEEP ]] && greenkeeper-lockfile-upload"
 after_success:
-  - [[ -n $HOUSEKEEP ]] && bash <(curl -s https://codecov.io/bash)
+  - "[[ -n $HOUSEKEEP ]] && bash <(curl -s https://codecov.io/bash)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ node_js:
   - "8"
   - "10"
 env:
-  - HOUSEKEEP=0
-  - HOUSEKEEP=1
-before_install:
-  - npm install -g greenkeeper-lockfile@1
-before_script: greenkeeper-lockfile-update
+  - HOUSEKEEP=
+  - HOUSEKEEP=yes
 matrix:
   exclude:
     - node_js: "6"
@@ -17,6 +14,9 @@ matrix:
       env: HOUSEKEEP=1
     - node_js: "10"
       env: HOUSEKEEP=0
+before_install:
+  - "if [ -n $HOUSEKEEP ]; then npm install -g greenkeeper-lockfile@1; fi"
+before_script: "if [ -n $HOUSEKEEP ]; then greenkeeper-lockfile-update; fi"
 script:
   - "if [ -n $HOUSEKEEP ]; then npm run lint; fi"
   - "if [ -n $HOUSEKEEP ]; then npm test -- --coverage; else npm test; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
 matrix:
   exclude:
     - node_js: "6"
-      env: HOUSEKEEP=1
+      env: HOUSEKEEP=yes
     - node_js: "8"
-      env: HOUSEKEEP=1
+      env: HOUSEKEEP=yes
     - node_js: "10"
-      env: HOUSEKEEP=0
+      env: HOUSEKEEP=
 before_install:
   - "if [ -n $HOUSEKEEP ]; then npm install -g greenkeeper-lockfile@1; fi"
 before_script: "if [ -n $HOUSEKEEP ]; then greenkeeper-lockfile-update; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ matrix:
     - node_js: "10"
       env: HOUSEKEEP=
 before_install:
-  - "if [ -n $HOUSEKEEP ]; then npm install -g greenkeeper-lockfile@1; fi"
-before_script: "if [ -n $HOUSEKEEP ]; then greenkeeper-lockfile-update; fi"
+  - "if [[ -n $HOUSEKEEP ]]; then npm install -g greenkeeper-lockfile@1; fi"
+before_script: "if [[ -n $HOUSEKEEP ]]; then greenkeeper-lockfile-update; fi"
 script:
-  - "if [ -n $HOUSEKEEP ]; then npm run lint; fi"
-  - "if [ -n $HOUSEKEEP ]; then npm test -- --coverage; else npm test; fi"
-  - "if [ -n $HOUSEKEEP ]; then npm run build; fi"
-after_script: "if [ -n $HOUSEKEEP ]; then greenkeeper-lockfile-upload; fi"
+  - "if [[ -n $HOUSEKEEP ]]; then npm run lint; fi"
+  - "if [[ -n $HOUSEKEEP ]]; then npm test -- --coverage; else npm test; fi"
+  - "if [[ -n $HOUSEKEEP ]]; then npm run build; fi"
+after_script: "if [[ -n $HOUSEKEEP ]]; then greenkeeper-lockfile-upload; fi"
 after_success:
-  - "if [ -n $HOUSEKEEP ]; then bash <(curl -s https://codecov.io/bash); fi"
+  - "if [[ -n $HOUSEKEEP ]]; then bash <(curl -s https://codecov.io/bash); fi"


### PR DESCRIPTION
Only run tests on old Node.js versions. All the "housekeeping" tasks only happen on the latest node.

There's definitely a better way to do this, but it works for now.