### PR TITLE
Ignore modules with transform ignore comment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
   env: {
     node: true,
   },
+  parserOptions: {
+    ecmaVersion: 2020,
+  },
   plugins: ['prettier'],
   extends: ['msrose', 'prettier'],
   rules: {

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,16 @@ jobs:
     - name: test
       run: npm test -- --coverage
     - name: examples
-      run: cd examples/transform-amd-to-commonjs-example && npm ci && npm test && npm run build && cd -
+      run:
+        - npm pack
+        - tar xvf babel-plugin-transform-amd-to-commonjs-*.tgz
+        - cd examples/transform-amd-to-commonjs-example
+        - npm ci
+        - npm test # test with latest published version
+        - npm i ../../package
+        - npm test # test with HEAD version
+        - npm run build
+        - cd -
     - name: upload coverage
       if: matrix['node-version'] == '16.x'
       run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,10 +32,9 @@ jobs:
         tar xvf babel-plugin-transform-amd-to-commonjs-*.tgz
         cd examples/transform-amd-to-commonjs-example
         npm ci
-        npm test # test with latest published version
-        npm i ../../package
-        npm test # test with HEAD version
-        npm run build
+        npm test && npm run build # test with latest published version
+        npm install ../../package
+        npm test && npm run build # test with HEAD version
         cd -
     - name: upload coverage
       if: matrix['node-version'] == '16.x'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,16 +27,16 @@ jobs:
     - name: test
       run: npm test -- --coverage
     - name: examples
-      run:
-        - npm pack
-        - tar xvf babel-plugin-transform-amd-to-commonjs-*.tgz
-        - cd examples/transform-amd-to-commonjs-example
-        - npm ci
-        - npm test # test with latest published version
-        - npm i ../../package
-        - npm test # test with HEAD version
-        - npm run build
-        - cd -
+      run: |
+        npm pack
+        tar xvf babel-plugin-transform-amd-to-commonjs-*.tgz
+        cd examples/transform-amd-to-commonjs-example
+        npm ci
+        npm test # test with latest published version
+        npm i ../../package
+        npm test # test with HEAD version
+        npm run build
+        cd -
     - name: upload coverage
       if: matrix['node-version'] == '16.x'
       run: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ AMD is interpreted as described by the [AMD specification](https://github.com/am
 
 ### Upgrading Versions
 
+#### 1.5.0
+
+Version 1.5.0 stops building against Node.js versions less than 12.x (and the built files target Node.js 12.x), so make sure you're using at least Node.js 12.x. There are no known breaking changes caused by this, but if you for some reason cannot upgrade Node.js and are running into errors, please open an issue.
+
 #### 1.0.0
 
 - Versions >= 0.2.1 and &lt; 1.0.0 support Node.js 4.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ Specify options in your .babelrc:
 
 - `restrictToTopLevelDefine`: (default: `true`) When `true`, only transform `define` calls that appear at the top-level of a program. Set to `false` to transform _all_ calls to `define`.
 
+## Escape Hatch
+
+If you need to ignore specific modules that are picked up by the plugin (for example, those that are erroneously detected as AMD modules), you can add an ignore comment at the top of the file:
+
+```
+/* transform-amd-to-commonjs-ignore */
+define(['stuff', 'here'], function(donkeys, aruba) {
+  return {
+      llamas: donkeys.version,
+      cows: aruba.hi
+  };
+});
+```
+
+The above module won't be transformed to CommonJS. The ignore comment must be at the beginning of the file and must be the only text in the comment block.
+
 ## Details
 
 ### Supported Versions

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,4 +7,5 @@ module.exports = {
   DEFINE: 'define',
   AMD_DEFINE_RESULT: 'amdDefineResult',
   MAYBE_FUNCTION: 'maybeFunction',
+  TRANSFORM_AMD_TO_COMMONJS_IGNORE: 'transform-amd-to-commonjs-ignore',
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { MODULE, EXPORTS, REQUIRE } = require('./constants');
+const { MODULE, EXPORTS, REQUIRE, TRANSFORM_AMD_TO_COMMONJS_IGNORE } = require('./constants');
 
 // A factory function is exported in order to inject the same babel-types object
 // being used by the plugin itself
@@ -188,6 +188,13 @@ module.exports = ({ types: t }) => {
     ];
   };
 
+  const hasIgnoreComment = (node) => {
+    const leadingComments = node.body?.[0]?.leadingComments || [];
+    return leadingComments.some(
+      ({ value }) => String(value).trim() === TRANSFORM_AMD_TO_COMMONJS_IGNORE
+    );
+  };
+
   return {
     decodeDefineArguments,
     decodeRequireArguments,
@@ -202,5 +209,6 @@ module.exports = ({ types: t }) => {
     createFactoryReplacementExpression,
     createFunctionCheck,
     isExplicitDependencyInjection,
+    hasIgnoreComment,
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const {
   DEFINE,
   AMD_DEFINE_RESULT,
   MAYBE_FUNCTION,
+  TRANSFORM_AMD_TO_COMMONJS_IGNORE,
 } = require('./constants');
 const createHelpers = require('./helpers');
 
@@ -37,7 +38,19 @@ module.exports = ({ types: t }) => {
     return array1.map((element, index) => [element, array2[index]]);
   };
 
+  let ignore = false;
+
+  const Program = (path) => {
+    const { node } = path;
+
+    ignore = (node.body[0]?.leadingComments || []).some(
+      ({ value }) => String(value).trim() === TRANSFORM_AMD_TO_COMMONJS_IGNORE
+    );
+  };
+
   const ExpressionStatement = (path, { opts }) => {
+    if (ignore) return;
+
     const { node, parent } = path;
 
     if (!t.isCallExpression(node.expression)) return;
@@ -140,6 +153,7 @@ module.exports = ({ types: t }) => {
 
   return {
     visitor: {
+      Program,
       ExpressionStatement,
     },
   };

--- a/tests/custom-matchers.js
+++ b/tests/custom-matchers.js
@@ -1,21 +1,25 @@
 'use strict';
 
 const babel = require('@babel/core');
-const diff = require('jest-diff');
+const { diff } = require('jest-diff');
 
 const transformAmdToCommonJS = (code, options = {}) => {
   return babel.transform(code, { plugins: [['./src/index', options]], babelrc: false }).code;
 };
 
-const transformTrivial = (code) => {
-  return babel.transform(code).code;
-};
+const normalize = (program) => {
+  const transformTrivial = (code) => {
+    return babel.transform(code).code;
+  };
 
-const removeBlankLines = (string) => {
-  return string
-    .split('\n')
-    .filter((line) => !!line.trim().length)
-    .join('\n');
+  const removeBlankLines = (string) => {
+    return string
+      .split('\n')
+      .filter((line) => !!line.trim().length)
+      .join('\n');
+  };
+
+  return removeBlankLines(transformTrivial(program));
 };
 
 const customMatchers = {
@@ -27,9 +31,9 @@ const customMatchers = {
       actual = actual.program;
     }
 
-    actual = removeBlankLines(transformTrivial(actual));
-    expected = removeBlankLines(transformTrivial(expected));
-    const transformed = removeBlankLines(transformAmdToCommonJS(actual, options));
+    actual = normalize(actual);
+    expected = normalize(expected);
+    const transformed = normalize(transformAmdToCommonJS(actual, options));
 
     const result = {
       pass: transformed === expected,

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const { AMD_DEFINE_RESULT, MAYBE_FUNCTION } = require('../src/constants');
+const {
+  AMD_DEFINE_RESULT,
+  MAYBE_FUNCTION,
+  TRANSFORM_AMD_TO_COMMONJS_IGNORE,
+} = require('../src/constants');
 const { checkAmdDefineResult, checkMaybeFunction } = require('./test-helpers');
 
 describe('Plugin for define blocks', () => {
@@ -550,4 +554,107 @@ describe('Plugin for define blocks', () => {
       })();
     `);
   });
+
+  it('ignores modules that have been excluded by block comments', () => {
+    const program = `
+      /* ${TRANSFORM_AMD_TO_COMMONJS_IGNORE} */
+      define(['stuff', 'here'], function(donkeys, aruba) {
+        return {
+           llamas: donkeys.version,
+           cows: aruba.hi
+        };
+      });
+    `;
+    expect(program).toBeTransformedTo(program);
+  });
+
+  it('ignores modules that have been excluded by line comments', () => {
+    const program = `
+      // ${TRANSFORM_AMD_TO_COMMONJS_IGNORE}
+      define(['stuff', 'here'], function(donkeys, aruba) {
+        return {
+           llamas: donkeys.version,
+           cows: aruba.hi
+        };
+      });
+    `;
+    expect(program).toBeTransformedTo(program);
+  });
+
+  it.each([TRANSFORM_AMD_TO_COMMONJS_IGNORE, 'a really nice comment'])(
+    'transforms normally with non-top-level block comments',
+    (comment) => {
+      expect(`
+        define(['stuff', 'here'], function(donkeys, aruba) {
+          /* ${comment} */
+          return {
+            llamas: donkeys.version,
+            cows: aruba.hi
+          };
+        });
+      `).toBeTransformedTo(`
+        module.exports = function() {
+          var donkeys = require('stuff');
+          var aruba = require('here');
+          /* ${comment} */
+          return {
+            llamas: donkeys.version,
+            cows: aruba.hi
+          };
+        }();
+      `);
+    }
+  );
+
+  it.each([TRANSFORM_AMD_TO_COMMONJS_IGNORE, 'a really nice comment'])(
+    'transforms normally with non-top-level line comments',
+    (comment) => {
+      expect(`
+        define(['stuff', 'here'], function(donkeys, aruba) {
+          // ${comment}
+          return {
+            llamas: donkeys.version,
+            cows: aruba.hi
+          };
+        });
+      `).toBeTransformedTo(`
+        module.exports = function() {
+          var donkeys = require('stuff');
+          var aruba = require('here');
+          // ${comment}
+          return {
+            llamas: donkeys.version,
+            cows: aruba.hi
+          };
+        }();
+      `);
+    }
+  );
+
+  it.each(['random comment', 'transform-amd-to-commonjs'])(
+    'transforms normally with random top-level comments',
+    (comment) => {
+      expect(`
+        /* ${comment} */
+        // ${comment}
+        define(['stuff', 'here'], function(donkeys, aruba) {
+          return {
+            llamas: donkeys.version,
+            cows: aruba.hi
+          };
+        });
+      `).toBeTransformedTo(`
+        /* ${comment} */
+        // ${comment}
+        module.exports = function() {
+          var donkeys = require('stuff');
+          var aruba = require('here');
+          return {
+            llamas: donkeys.version,
+            cows: aruba.hi
+          };
+        }();
+      `);
+    }
+  );
 });

--- a/tests/require.test.js
+++ b/tests/require.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { TRANSFORM_AMD_TO_COMMONJS_IGNORE } = require('../src/constants');
+
 describe('Plugin for require blocks', () => {
   it('transforms require blocks with one dependency', () => {
     expect(`
@@ -173,4 +175,91 @@ describe('Plugin for require blocks', () => {
       })();
     `);
   });
+
+  it('ignores modules that have been excluded by block comments', () => {
+    const program = `
+      /* ${TRANSFORM_AMD_TO_COMMONJS_IGNORE} */
+      require(['llamas', 'frogs'], function(llama, frog) {
+        llama.doSomeStuff();
+        frog.sayRibbit();
+      });
+    `;
+    expect(program).toBeTransformedTo(program);
+  });
+
+  it('ignores modules that have been excluded by line comments', () => {
+    const program = `
+      // ${TRANSFORM_AMD_TO_COMMONJS_IGNORE}
+      require(['llamas', 'frogs'], function(llama, frog) {
+        llama.doSomeStuff();
+        frog.sayRibbit();
+      });
+    `;
+    expect(program).toBeTransformedTo(program);
+  });
+
+  it.each([TRANSFORM_AMD_TO_COMMONJS_IGNORE, 'a really nice comment'])(
+    'transforms normally with non-top-level block comments',
+    (comment) => {
+      expect(`
+        require(['llamas', 'frogs'], function(llama, frog) {
+          /* ${comment} */
+          llama.doSomeStuff();
+          frog.sayRibbit();
+        });
+      `).toBeTransformedTo(`
+        (function() {
+          var llama = require('llamas');
+          var frog = require('frogs');
+          /* ${comment} */
+          llama.doSomeStuff();
+          frog.sayRibbit();
+        })();
+      `);
+    }
+  );
+
+  it.each([TRANSFORM_AMD_TO_COMMONJS_IGNORE, 'a really nice comment'])(
+    'transforms normally with non-top-level line comments',
+    (comment) => {
+      expect(`
+        require(['llamas', 'frogs'], function(llama, frog) {
+          // ${comment}
+          llama.doSomeStuff();
+          frog.sayRibbit();
+        });
+      `).toBeTransformedTo(`
+        (function() {
+          var llama = require('llamas');
+          var frog = require('frogs');
+          // ${comment}
+          llama.doSomeStuff();
+          frog.sayRibbit();
+        })();
+      `);
+    }
+  );
+
+  it.each(['random comment', 'transform-amd-to-commonjs'])(
+    'transforms normally with random top-level comments',
+    (comment) => {
+      expect(`
+        /* ${comment} */
+        // ${comment}
+        require(['llamas', 'frogs'], function(llama, frog) {
+          llama.doSomeStuff();
+          frog.sayRibbit();
+        });
+      `).toBeTransformedTo(`
+        /* ${comment} */
+        // ${comment}
+        (function() {
+          var llama = require('llamas');
+          var frog = require('frogs');
+          llama.doSomeStuff();
+          frog.sayRibbit();
+        })();
+      `);
+    }
+  );
 });


### PR DESCRIPTION
#288 

Provides the ability to opt-out of transformation with a module-level comment.

~Make sure to test with real project before publishing - multiple module case important to verify since there is some global state happening.~ Done.

~Can can consider doing recursive traversal instead of global state, but might require larger refactor: https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#state~ Done.

~Need to update README.~ Done.