### PR TITLE
Add support for require/define with unknown arg types at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Make sure that you have only one AMD module defined per file, otherwise you'll e
 
 ### Listing module dependencies inline (v1.6 and above)
 
-In v1.6, require dependencies and factories with unknown types (at build time) are now supported.  The dependency list may be a function call or variable name that resolves to an array type at runtime.  The factory may be a function call or variable name that resolves to a function at runtime.
+In v1.6, require dependencies and factories with unknown types (at build time) are now supported.  The dependency list may be a function call or variable name that resolves to an array-like type at runtime.  The factory may be a function call or variable name that resolves to a function at runtime.
 
 ```javascript
 require(getDeps(), myFactoryFunction);
@@ -166,7 +166,7 @@ will be transformed to:
 (function () {
   var maybeFunction = myFactoryFunction;
   var amdDeps = getDeps();
-  if (!Array.isArray(amdDeps)) {
+  if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
     return require(amdDeps);
   }
   if (typeof maybeFunction !== "function") {

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ will be transformed to:
   if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
     return require(amdDeps);
   }
+  amdDeps = [].slice.call(amdDeps);
   if (typeof maybeFunction !== "function") {
     maybeFunction = function () {};
   }

--- a/README.md
+++ b/README.md
@@ -152,7 +152,39 @@ Version 1.5.0 stops building against Node.js versions less than 12.x (and the bu
 
 Make sure that you have only one AMD module defined per file, otherwise you'll experience strange results once transformed to the CommonJS format.
 
-### Listing module dependencies inline
+### Listing module dependencies inline (v1.6 and above)
+
+In v1.6, require dependencies and factories with unknown types (at build time) are now supported.  The dependency list may be a function call or variable name that resolves to an array type at runtime.  The factory may be a function call or variable name that resolves to a function at runtime.
+
+```javascript
+require(getDeps(), myFactoryFunction);
+```
+
+will be transformed to:
+
+```javascript
+(function () {
+  var maybeFunction = myFactoryFunction;
+  var amdDeps = getDeps();
+  if (!Array.isArray(amdDeps)) {
+    return require(amdDeps);
+  }
+  if (typeof maybeFunction !== "function") {
+    maybeFunction = function () {};
+  }
+  maybeFunction.apply(void 0, amdDeps.map(function (dep) {
+    return {
+      require: require,
+      module: module,
+      exports: module.exports
+    }[dep] || require(dep);
+  }));
+}).apply(this);
+```
+
+If either the dependency list is known to be an array, or the factory is known to be a function, at build time then the associated runtime type checking for the argument is omitted from the generated code.
+
+### Listing module dependencies inline (v1.5)
 
 The following will _not_ be transformed, since the plugin only accounts for dependencies that are specified using an inline array literal:
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,4 +8,5 @@ module.exports = {
   AMD_DEFINE_RESULT: 'amdDefineResult',
   MAYBE_FUNCTION: 'maybeFunction',
   TRANSFORM_AMD_TO_COMMONJS_IGNORE: 'transform-amd-to-commonjs-ignore',
+  AMD_DEPS: 'amdDeps',
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ module.exports = {
   EXPORTS: 'exports',
   DEFINE: 'define',
   AMD_DEFINE_RESULT: 'amdDefineResult',
+  AMD_FACTORY_RESULT: 'amdFactoryResult',
   MAYBE_FUNCTION: 'maybeFunction',
   TRANSFORM_AMD_TO_COMMONJS_IGNORE: 'transform-amd-to-commonjs-ignore',
   AMD_DEPS: 'amdDeps',

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { MODULE, EXPORTS, REQUIRE, TRANSFORM_AMD_TO_COMMONJS_IGNORE } = require('./constants');
+const { MODULE, EXPORTS, REQUIRE, TRANSFORM_AMD_TO_COMMONJS_IGNORE, MAYBE_FUNCTION, AMD_DEPS } = require('./constants');
 
 // A factory function is exported in order to inject the same babel-types object
 // being used by the plugin itself
@@ -195,6 +195,112 @@ module.exports = ({ types: t }) => {
     );
   };
 
+  const getAmdFactoryArgsMapper = () => {
+    // Returns the factory args genrator function.
+    //
+    // function(dep) {
+    //   return {
+    //     require: require,
+    //     module: module,
+    //     exports: module.exports
+    //   }[dep] || require(dep);
+    // }
+    const moduleIdent = t.identifier(MODULE);
+    const requireIdent = t.identifier(REQUIRE);
+    const exportsIdent = t.identifier(EXPORTS);
+    const DEP = 'dep';
+    return t.functionExpression(null, [t.identifier(DEP)], t.blockStatement([
+      t.returnStatement(
+        t.logicalExpression(
+          '||',
+          t.memberExpression(
+            t.objectExpression([
+              t.objectProperty(requireIdent, requireIdent),
+              t.objectProperty(moduleIdent, moduleIdent),
+              t.objectProperty(exportsIdent, t.memberExpression(moduleIdent, exportsIdent))
+            ]),
+            t.identifier(DEP),
+            true
+          ),
+          t.callExpression(t.identifier(REQUIRE), [t.identifier(DEP)])
+        )
+      )
+    ]));
+  };
+
+  const createRequireReplacementWithUnknownVarTypes = (path, opts, dependencyList, factory) => {
+    const factoryIdentifier = getUniqueIdentifier(path.scope, MAYBE_FUNCTION);
+    const depsIdentifier = getUniqueIdentifier(path.scope, AMD_DEPS);
+    const blockStatements = [];
+
+    // Define block scoped variables 'maybeFunction' and 'amdDeps'.
+    blockStatements.push(t.variableDeclaration('var', [t.variableDeclarator(factoryIdentifier, factory)]));
+    blockStatements.push(t.variableDeclaration('var', [t.variableDeclarator(depsIdentifier, dependencyList)]));
+
+    // If we don't know that the dependency list is an array, then we need to check
+    // the type at runtime.
+    if (!t.isArrayExpression(dependencyList)) {
+      // if (!Array.isArray(amdDeps)) {
+      //   return require(amdDeps);
+      // }
+      blockStatements.push(
+        t.ifStatement(
+          t.unaryExpression('!', t.callExpression(t.memberExpression(t.identifier('Array'),t.identifier('isArray')), [depsIdentifier])),
+          t.blockStatement([
+            t.returnStatement(t.callExpression(t.identifier(REQUIRE), [depsIdentifier]))
+          ])
+        )
+      );
+    }
+
+    // If we don't know that the factory is a function, the we need to check the type
+    // at runtime.
+    if (!isFunctionExpression(factory)) {
+      // if (typeof maybeFunction !== 'function') {
+      //   maybeFunction = function () {};
+      // }
+      blockStatements.push(
+        t.ifStatement(
+          t.binaryExpression('!==', t.unaryExpression('typeof', factoryIdentifier), t.stringLiteral('function')),
+          t.blockStatement([
+            t.expressionStatement(t.assignmentExpression('=', factoryIdentifier, t.functionExpression(null, [], t.blockStatement([]))))
+          ])
+        )
+      );
+    }
+    // Invoke the factory function.
+    blockStatements.push(t.expressionStatement(t.callExpression(t.memberExpression(factoryIdentifier, t.identifier('apply')),
+      [
+        /*
+         * The 'this' argument for the factory function.
+         * 'void 0'
+         */
+        t.unaryExpression('void', t.numericLiteral(0)),
+
+        /*
+         * The arguments to the factory function as an array.
+         * 'deps.map(amdFactoryArgsGenerator)''
+         */
+        t.callExpression(
+          t.memberExpression(
+            depsIdentifier,
+            t.identifier('map')
+          ),
+          [getAmdFactoryArgsMapper(path, opts)]
+        )
+      ]
+    )));
+    // Wrap it all up in an IIF, being sure to preserve the 'this' reference from
+    // outer scope.
+    return t.callExpression(
+      t.memberExpression(
+        t.parenthesizedExpression(t.functionExpression(null, [], t.blockStatement(blockStatements))),
+        t.identifier('apply')
+      ),
+      [t.thisExpression()]
+    );
+  };
+
   return {
     decodeDefineArguments,
     decodeRequireArguments,
@@ -210,5 +316,7 @@ module.exports = ({ types: t }) => {
     createFunctionCheck,
     isExplicitDependencyInjection,
     hasIgnoreComment,
+    getAmdFactoryArgsMapper,
+    createRequireReplacementWithUnknownVarTypes,
   };
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -255,16 +255,25 @@ module.exports = ({ types: t }) => {
     // If we don't know that the dependency list is an array, then we need to check
     // the type at runtime.
     if (!t.isArrayExpression(dependencyList)) {
-      // if (!Array.isArray(amdDeps)) {
+      // if (amdDeps === null || typeof amdDeps !== 'object' || isNaN(amdDeps.length)) {
       //   return require(amdDeps);
       // }
       blockStatements.push(
         t.ifStatement(
-          t.unaryExpression(
-            '!',
-            t.callExpression(t.memberExpression(t.identifier('Array'), t.identifier('isArray')), [
-              depsIdentifier,
-            ])
+          t.logicalExpression(
+            '||',
+            t.binaryExpression('===', depsIdentifier, t.nullLiteral()),
+            t.logicalExpression(
+              '||',
+              t.binaryExpression(
+                '!==',
+                t.unaryExpression('typeof', depsIdentifier),
+                t.stringLiteral('object')
+              ),
+              t.callExpression(t.identifier('isNaN'), [
+                t.memberExpression(depsIdentifier, t.identifier('length')),
+              ])
+            )
           ),
           t.blockStatement([
             t.returnStatement(t.callExpression(t.identifier(REQUIRE), [depsIdentifier])),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -280,6 +280,23 @@ module.exports = ({ types: t }) => {
           ])
         )
       );
+      // Convert array-like objects to real arrays
+      // amdDeps = [].slice.call(amdDeps);
+      blockStatements.push(
+        t.expressionStatement(
+          t.assignmentExpression(
+            '=',
+            depsIdentifier,
+            t.callExpression(
+              t.memberExpression(
+                t.memberExpression(t.arrayExpression(), t.identifier('slice')),
+                t.identifier('call')
+              ),
+              [depsIdentifier]
+            )
+          )
+        )
+      );
     }
 
     // If we don't know that the factory is a function, the we need to check the type

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,7 +19,7 @@ module.exports = ({ types: t }) => {
       return { factory: argNodes[0] };
     } else if (argNodes.length === 2) {
       const decodedArgs = { factory: argNodes[1] };
-      if (t.isArrayExpression(argNodes[0])) {
+      if (!t.isStringLiteral(argNodes[0])) {
         decodedArgs.dependencyList = argNodes[0];
       }
       return decodedArgs;

--- a/src/index.js
+++ b/src/index.js
@@ -102,9 +102,14 @@ module.exports = ({ types: t }) => {
 
     const explicitDependencyInjections = dependencyInjections.filter(isExplicitDependencyInjection);
 
-    if (!isDefineCall && (factory && !isFunctionFactory || !t.isArrayExpression(dependencyList))) {
+    if (
+      !isDefineCall &&
+      ((factory && !isFunctionFactory) || !t.isArrayExpression(dependencyList))
+    ) {
       // require call with unknown factory type and/or non-array litteral dependencies.
-      path.replaceWithMultiple(createRequireReplacementWithUnknownVarTypes(path, opts, dependencyList, factory));
+      path.replaceWithMultiple(
+        createRequireReplacementWithUnknownVarTypes(path, opts, dependencyList, factory)
+      );
     } else if (isFunctionFactory) {
       const factoryArity = factory.params.length;
       let replacementFuncExpr = createFactoryReplacementExpression(

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,8 @@ module.exports = ({ types: t }) => {
           opts,
           dependencyList,
           factory,
-          isDefineCall
+          isDefineCall,
+          node.expression.arguments.length
         )
       );
       return;

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { AMD_DEFINE_RESULT, TRANSFORM_AMD_TO_COMMONJS_IGNORE } = require('../src/constants');
-const { checkAmdDefineResult, checkMaybeFunction, checkVarArgsResult } = require('./test-helpers');
+const { checkAmdDefineResult, checkMaybeFunction } = require('./test-helpers');
 
 describe('Plugin for define blocks with arrow function factories', () => {
   it('transforms anonymous define blocks with one dependency', () => {
@@ -455,7 +455,7 @@ describe('Plugin for define blocks with arrow function factories', () => {
       define(['stuff', 'hi'], myVariableFactory)
     `).toBeTransformedTo(`
       ${variableFactory}
-      ${checkVarArgsResult('myVariableFactory', "['stuff', 'hi']", false, true, true)}
+      ${checkMaybeFunction('myVariableFactory', ['stuff', 'hi'])}
     `);
   });
 

--- a/tests/define-arrow.test.js
+++ b/tests/define-arrow.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { AMD_DEFINE_RESULT, TRANSFORM_AMD_TO_COMMONJS_IGNORE } = require('../src/constants');
-const { checkAmdDefineResult, checkMaybeFunction } = require('./test-helpers');
+const { checkAmdDefineResult, checkMaybeFunction, checkVarArgsResult } = require('./test-helpers');
 
 describe('Plugin for define blocks with arrow function factories', () => {
   it('transforms anonymous define blocks with one dependency', () => {
@@ -455,7 +455,7 @@ describe('Plugin for define blocks with arrow function factories', () => {
       define(['stuff', 'hi'], myVariableFactory)
     `).toBeTransformedTo(`
       ${variableFactory}
-      ${checkMaybeFunction('myVariableFactory', ['stuff', 'hi'])}
+      ${checkVarArgsResult('myVariableFactory', "['stuff', 'hi']", false, true, true)}
     `);
   });
 

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -5,7 +5,7 @@ const {
   MAYBE_FUNCTION,
   TRANSFORM_AMD_TO_COMMONJS_IGNORE,
 } = require('../src/constants');
-const { checkAmdDefineResult, checkMaybeFunction } = require('./test-helpers');
+const { checkAmdDefineResult, checkMaybeFunction, checkVarArgsResult } = require('./test-helpers');
 
 describe('Plugin for define blocks', () => {
   it('transforms anonymous define blocks with one dependency', () => {
@@ -389,7 +389,9 @@ describe('Plugin for define blocks', () => {
   it('transforms non-function modules exporting objects with dependencies', () => {
     expect(`
       define(['side-effect'], { thismodule: 'is an object' });
-    `).toBeTransformedTo(checkMaybeFunction("{ thismodule: 'is an object' }", ['side-effect']));
+    `).toBeTransformedTo(
+      checkVarArgsResult("{ thismodule: 'is an object' }", "['side-effect']", false, true, true)
+    );
   });
 
   it('transforms non-function modules exporting arrays with no dependencies', () => {
@@ -402,7 +404,13 @@ describe('Plugin for define blocks', () => {
     expect(`
       define(['side-effect'], ['this', 'module', 'is', 'an', 'array']);
     `).toBeTransformedTo(
-      checkMaybeFunction("['this', 'module', 'is', 'an', 'array']", ['side-effect'])
+      checkVarArgsResult(
+        "['this', 'module', 'is', 'an', 'array']",
+        "['side-effect']",
+        false,
+        true,
+        true
+      )
     );
   });
 
@@ -420,35 +428,41 @@ describe('Plugin for define blocks', () => {
     primitives.forEach((primitive) => {
       expect(`
         define(['side-effect'], ${primitive});
-      `).toBeTransformedTo(checkMaybeFunction(primitive, ['side-effect']));
+      `).toBeTransformedTo(checkVarArgsResult(primitive, "['side-effect']", false, true, true));
     });
   });
 
   it('transforms non-function modules requiring `require` for some reason', () => {
     expect(`
       define(['require'], { some: 'stuff' });
-    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['require']));
+    `).toBeTransformedTo(checkVarArgsResult("{ some: 'stuff' }", "['require']", false, true, true));
     expect(`
       define(['sup', 'require'], { some: 'stuff' });
-    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['sup', 'require']));
+    `).toBeTransformedTo(
+      checkVarArgsResult("{ some: 'stuff' }", "['sup', 'require']", false, true, true)
+    );
   });
 
   it('transforms non-function modules requiring `exports` for some reason', () => {
     expect(`
       define(['exports'], { some: 'stuff' });
-    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['exports']));
+    `).toBeTransformedTo(checkVarArgsResult("{ some: 'stuff' }", "['exports']", false, true, true));
     expect(`
       define(['exports', 'dawg'], { some: 'stuff' });
-    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['exports', 'dawg']));
+    `).toBeTransformedTo(
+      checkVarArgsResult("{ some: 'stuff' }", "['exports', 'dawg']", false, true, true)
+    );
   });
 
   it('transforms non-function modules requiring `module` for some reason', () => {
     expect(`
       define(['module'], { some: 'stuff' });
-    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['module']));
+    `).toBeTransformedTo(checkVarArgsResult("{ some: 'stuff' }", "['module']", false, true, true));
     expect(`
       define(['module', 'lemon'], { some: 'stuff' });
-    `).toBeTransformedTo(checkMaybeFunction("{ some: 'stuff' }", ['module', 'lemon']));
+    `).toBeTransformedTo(
+      checkVarArgsResult("{ some: 'stuff' }", "['module', 'lemon']", false, true, true)
+    );
   });
 
   it('transforms named non-function modules with no dependencies', () => {
@@ -463,10 +477,14 @@ describe('Plugin for define blocks', () => {
   it('transforms named non-function modules with dependencies', () => {
     expect(`
       define('auselessname', ['side-effect'], { thismodule: 'is an object' });
-    `).toBeTransformedTo(checkMaybeFunction("{ thismodule: 'is an object' }", ['side-effect']));
+    `).toBeTransformedTo(
+      checkVarArgsResult("{ thismodule: 'is an object' }", "['side-effect']", false, true, true)
+    );
     expect(`
       define('auselessname', ['side-effect'], ['an', 'array', 'factory']);
-    `).toBeTransformedTo(checkMaybeFunction("['an', 'array', 'factory']", ['side-effect']));
+    `).toBeTransformedTo(
+      checkVarArgsResult("['an', 'array', 'factory']", "['side-effect']", false, true, true)
+    );
   });
 
   it('checks non function-literal factories to see if they are actually functions', () => {
@@ -474,14 +492,14 @@ describe('Plugin for define blocks', () => {
       var myVariableFactory = function(stuff, hi) {
         stuff.what(hi)
         return { great: 'stuff' };
-      }
+      };
     `;
     expect(`
       ${variableFactory}
       define(['stuff', 'hi'], myVariableFactory)
     `).toBeTransformedTo(`
       ${variableFactory}
-      ${checkMaybeFunction('myVariableFactory', ['stuff', 'hi'])}
+      ${checkVarArgsResult('myVariableFactory', "['stuff', 'hi']", false, true, true)}
     `);
   });
 

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -676,21 +676,48 @@ describe('Plugin for define blocks', () => {
     }
   );
 
-  it('transforms define call that use non-array literal dependency list and non function factory', () => {
+  it('transforms define call that use var args dependency list and factory', () => {
     expect(`
       define(deps, factory);
     `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true, true));
   });
 
-  it('transforms named define call that use non-array literal dependency list and non function factory', () => {
+  it('transforms named define call that uses var args dependency list and factory', () => {
     expect(`
       define('somename', deps, factory);
     `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
   });
 
-  it('transforms named define call that use non-literals for all three arguments', () => {
+  it('transforms named define call that use var args for all three arguments', () => {
     expect(`
       define(name, deps, factory);
     `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
+  });
+
+  it('transforms define with var arg dependency list', () => {
+    expect(`
+      define(deps, function(foo, bar) {
+        foo.doSomething();
+        bar.doSomethingElse();
+      });
+    `).toBeTransformedTo(
+      checkVarArgsResult(
+        `function(foo, bar) {
+          foo.doSomething();
+          bar.doSomethingElse();
+        }`,
+        'deps',
+        true,
+        false,
+        true,
+        true
+      )
+    );
+  });
+
+  it('transforms define with var arg factory', () => {
+    expect(`
+      define(['dep1', 'dep2'], factory);
+    `).toBeTransformedTo(checkVarArgsResult('factory', "['dep1', 'dep2']", false, true, true));
   });
 });

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -5,7 +5,11 @@ const {
   MAYBE_FUNCTION,
   TRANSFORM_AMD_TO_COMMONJS_IGNORE,
 } = require('../src/constants');
-const { checkAmdDefineResult, checkMaybeFunction, checkVarArgsResult } = require('./test-helpers');
+const {
+  checkAmdDefineResult,
+  checkMaybeFunction,
+  checkVariableDepAndFactoryResult,
+} = require('./test-helpers');
 
 describe('Plugin for define blocks', () => {
   it('transforms anonymous define blocks with one dependency', () => {
@@ -662,7 +666,7 @@ describe('Plugin for define blocks', () => {
     expect(`
       define(deps, factory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factory',
         dependencies: 'deps',
         checkDeps: true,
@@ -677,7 +681,7 @@ describe('Plugin for define blocks', () => {
     expect(`
       define('somename', deps, factory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factory',
         dependencies: 'deps',
         checkDeps: true,
@@ -691,7 +695,7 @@ describe('Plugin for define blocks', () => {
     expect(`
       define(name, deps, factory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factory',
         dependencies: 'deps',
         checkDeps: true,
@@ -708,7 +712,7 @@ describe('Plugin for define blocks', () => {
         bar.doSomethingElse();
       });
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: `function(foo, bar) {
           foo.doSomething();
           bar.doSomethingElse();

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -679,12 +679,18 @@ describe('Plugin for define blocks', () => {
   it('transforms define call that use non-array literal dependency list and non function factory', () => {
     expect(`
       define(deps, factory);
-    `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
+    `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true, true));
   });
 
   it('transforms named define call that use non-array literal dependency list and non function factory', () => {
     expect(`
       define('somename', deps, factory);
+    `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
+  });
+
+  it('transforms named define call that use non-literals for all three arguments', () => {
+    expect(`
+      define(name, deps, factory);
     `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
   });
 });

--- a/tests/define.test.js
+++ b/tests/define.test.js
@@ -675,4 +675,16 @@ describe('Plugin for define blocks', () => {
       `);
     }
   );
+
+  it('transforms define call that use non-array literal dependency list and non function factory', () => {
+    expect(`
+      define(deps, factory);
+    `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
+  });
+
+  it('transforms named define call that use non-array literal dependency list and non function factory', () => {
+    expect(`
+      define('somename', deps, factory);
+    `).toBeTransformedTo(checkVarArgsResult('factory', 'deps', true, true, true));
+  });
 });

--- a/tests/require.test.js
+++ b/tests/require.test.js
@@ -266,7 +266,7 @@ describe('Plugin for require blocks', () => {
           bar.doSomethingElse();
         };
         var amdDeps = deps;
-        if (!Array.isArray(amdDeps)) {
+        if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
           return require(amdDeps);
         }
         maybeFunction.apply(void 0, amdDeps.map(function (dep) {
@@ -308,7 +308,7 @@ describe('Plugin for require blocks', () => {
       (function () {
         var maybeFunction = factory;
         var amdDeps = deps;
-        if (!Array.isArray(amdDeps)) {
+        if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
           return require(amdDeps);
         }
         if (typeof maybeFunction !== "function") {

--- a/tests/require.test.js
+++ b/tests/require.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { TRANSFORM_AMD_TO_COMMONJS_IGNORE } = require('../src/constants');
-const { checkVarArgsResult } = require('./test-helpers');
+const { checkVariableDepAndFactoryResult } = require('./test-helpers');
 
 describe('Plugin for require blocks', () => {
   it('transforms require blocks with one dependency', () => {
@@ -271,7 +271,7 @@ describe('Plugin for require blocks', () => {
         bar.doSomethingElse();
       });
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: `function(foo, bar) {
           foo.doSomething();
           bar.doSomethingElse();
@@ -288,7 +288,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(deps, factory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factory',
         dependencies: 'deps',
         checkDeps: true,
@@ -302,7 +302,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], this.factory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'this.factory',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -316,7 +316,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], foo?.factory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'foo?.factory',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -330,7 +330,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], getFactory());
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'getFactory()',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -344,7 +344,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], getFactory?.());
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'getFactory?.()',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -358,7 +358,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], factories[i]);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factories[i]',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -372,7 +372,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], factory1 || factory2);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factory1 || factory2',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -386,7 +386,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], foo ? factory1 : factory2);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'foo ? factory1 : factory2',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -400,7 +400,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], factory = myFactory);
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: 'factory = myFactory',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,
@@ -414,7 +414,7 @@ describe('Plugin for require blocks', () => {
     expect(`
       require(["dep1", "dep2"], (factory = myFactory));
     `).toBeTransformedTo(
-      checkVarArgsResult({
+      checkVariableDepAndFactoryResult({
         factory: '(factory = myFactory)',
         dependencies: '["dep1", "dep2"]',
         checkDeps: false,

--- a/tests/require.test.js
+++ b/tests/require.test.js
@@ -269,6 +269,7 @@ describe('Plugin for require blocks', () => {
         if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
           return require(amdDeps);
         }
+        amdDeps = [].slice.call(amdDeps);
         maybeFunction.apply(void 0, amdDeps.map(function (dep) {
           return {
             require: require,
@@ -311,6 +312,7 @@ describe('Plugin for require blocks', () => {
         if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
           return require(amdDeps);
         }
+        amdDeps = [].slice.call(amdDeps);
         if (typeof maybeFunction !== "function") {
           maybeFunction = function () {};
         }

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -36,7 +36,14 @@ const checkMaybeFunction = (factory, dependencies, identifier = MAYBE_FUNCTION) 
     `;
 };
 
-const checkVarArgsResult = (factory, dependencies, checkDeps, checkFactory, isDefineCall) => {
+const checkVarArgsResult = (
+  factory,
+  dependencies,
+  checkDeps,
+  checkFactory,
+  isDefineCall,
+  checkForModuleName
+) => {
   const requireFactoryResult = `
     maybeFunction = function() {};
   `;
@@ -56,12 +63,22 @@ const checkVarArgsResult = (factory, dependencies, checkDeps, checkFactory, isDe
   }
   let depsCheck = '';
   if (checkDeps) {
-    depsCheck = `
-    if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
-      return require(amdDeps);
+    if (isDefineCall) {
+      if (checkForModuleName) {
+        depsCheck = `
+        if (typeof amdDeps === "string") {
+          amdDeps = ["require", "exports", "module"];
+        }
+        `;
+      }
+    } else {
+      depsCheck = `
+      if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
+        return require(amdDeps);
+      }
+      `;
     }
-    amdDeps = [].slice.call(amdDeps);
-    `;
+    depsCheck += '\namdDeps = [].slice.call(amdDeps);';
   }
 
   return `

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -36,14 +36,14 @@ const checkMaybeFunction = (factory, dependencies, identifier = MAYBE_FUNCTION) 
     `;
 };
 
-const checkVarArgsResult = (
+const checkVarArgsResult = ({
   factory,
   dependencies,
   checkDeps,
   checkFactory,
   isDefineCall,
-  checkForModuleName
-) => {
+  checkForModuleName,
+}) => {
   const requireFactoryResult = `
     maybeFunction = function() {};
   `;
@@ -73,12 +73,11 @@ const checkVarArgsResult = (
       }
     } else {
       depsCheck = `
-      if (amdDeps === null || typeof amdDeps !== "object" || isNaN(amdDeps.length)) {
+      if (!Array.isArray(amdDeps)) {
         return require(amdDeps);
       }
       `;
     }
-    depsCheck += '\namdDeps = [].slice.call(amdDeps);';
   }
 
   return `

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -36,7 +36,7 @@ const checkMaybeFunction = (factory, dependencies, identifier = MAYBE_FUNCTION) 
     `;
 };
 
-const checkVarArgsResult = ({
+const checkVariableDepAndFactoryResult = ({
   factory,
   dependencies,
   checkDeps,
@@ -106,5 +106,5 @@ const checkVarArgsResult = ({
 module.exports = {
   checkAmdDefineResult,
   checkMaybeFunction,
-  checkVarArgsResult,
+  checkVariableDepAndFactoryResult,
 };


### PR DESCRIPTION
Will transform
```javascript
  require(getDeps(), myFactoryFunction);
```
to
```javascript
(function () {
  var maybeFunction = myFactoryFunction;
  var amdDeps = getDeps();
  if (Array.isArray(amdDeps) {
    return require(amdDeps);
  }
  if (typeof maybeFunction !== "function") {
    maybeFunction = function () {};
  }
  maybeFunction.apply(void 0, amdDeps.map(function (dep) {
    return {
      require: require,
      module: module,
      exports: module.exports
    }[dep] || require(dep);
  }));
}).apply(this);
```
If either the dependency list is known to be an array, or the factory is known to be a function, at build time then the associated runtime type checking for the argument is omitted from the generated code.

define calls are transformed in a similar manner, but include code for assigning the value returned by the factory function to `module.exports`.

```javascript
(function () {
  var maybeFunction = factory;
  var amdDeps = deps;
  if (typeof amdDeps === 'string') {
    amdDeps = ['require', 'exports', 'module'];
  }
  if (typeof maybeFunction !== "function") {
    var amdFactoryResult = maybeFunction;
    maybeFunction = function () {
      return amdFactoryResult;
    };
  }
  var amdDefineResult = maybeFunction.apply(void 0, amdDeps.map(function (dep) {
    return {
      require: require,
      module: module,
      exports: module.exports
    }[dep] || require(dep);
  }));
  typeof amdDefineResult !== "undefined" && (module.exports = amdDefineResult);
}).apply(this);
```