### PR TITLE
fix(zip): check if array is empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,10 @@ module.exports = ({ types: t }) => {
 
   // Simple version of zip that only pairs elements until the end of the first array
   const zip = (array1, array2) => {
-    return array1.map((element, index) => [element, array2[index]]);
+    if (array1) {
+      return array1.map((element, index) => [element, array2[index]]);
+    }
+    return [];
   };
 
   const Program = (path, ...rest) => {


### PR DESCRIPTION
When processing a file in my project, I started to receive the following error ->

```
TypeError: /Users/briamart/gitlab/gbu-rapid/packages/rapid-jet/exchange_components/oj-dynamic/utils/DynamicComponentUtil.js: Cannot read properties of undefined (reading 'map')

      at zip (node_modules/babel-plugin-transform-amd-to-commonjs/build/index.js:41:19)
      at PluginPass.ExpressionStatement (node_modules/babel-plugin-transform-amd-to-commonjs/build/index.js:81:40)
      at NodePath._call (node_modules/@babel/traverse/lib/path/context.js:53:20)
      at NodePath.call (node_modules/@babel/traverse/lib/path/context.js:40:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:100:31)
      at TraversalContext.visitQueue (node_modules/@babel/traverse/lib/context.js:103:16)
      at TraversalContext.visitMultiple (node_modules/@babel/traverse/lib/context.js:72:17)
      at TraversalContext.visit (node_modules/@babel/traverse/lib/context.js:129:19)
      at traverseNode (node_modules/@babel/traverse/lib/traverse-node.js:24:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:107:52)
```
It appears that, in some instances, `array1` in the zip function can be undefined, leading to the above issue. I am implementing a check here that the value must be something "truthy" (which should always be an array) otherwise returning an empty array.