### PR TITLE
Drop Node.js 12 from build

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Node.js 12 LTS has ended, and jest-diff doesn't work with it any longer.